### PR TITLE
feat: support for specifying a space environment when creating a client

### DIFF
--- a/foomo/gocontentful/command.go
+++ b/foomo/gocontentful/command.go
@@ -145,8 +145,14 @@ func (c *Command) execute(ctx context.Context, r *readline.Readline) error {
 			return errors.Wrap(err, string(out))
 		}
 
+		// "master" is the built-in default environment name of contentful
+		// fallback to it if the configuration does not ask specifically for an environment
+		if cfg.Environment == "" {
+			cfg.Environment = "master"
+		}
+
 		if err := shell.New(ctx, c.l, "gocontentful",
-			"-spaceid", cfg.SpaceID, "-cmakey", cfg.CMAKey,
+			"-spaceid", cfg.SpaceID, "-cmakey", cfg.CMAKey, "-environment", cfg.Environment,
 			"-contenttypes", strings.Join(cfg.ContentTypes, ","), dir).
 			Args(r.AdditionalArgs()...).
 			Run(); err != nil {

--- a/foomo/gocontentful/config.go
+++ b/foomo/gocontentful/config.go
@@ -3,5 +3,6 @@ package gocontentful
 type Config struct {
 	SpaceID      string   `yaml:"spaceId"`
 	CMAKey       string   `yaml:"cmaKey"`
+	Environment  string   `yaml:"environment,omitempty"`
 	ContentTypes []string `yaml:"contentTypes"`
 }


### PR DESCRIPTION
The underlying command allows specifying an environment on the -environment flag.