### PR TITLE
feat(k3d): allow passing extra cluster args from config

### DIFF
--- a/k3d-io/k3d/README.md
+++ b/k3d-io/k3d/README.md
@@ -55,6 +55,9 @@ k3d:
       alias: foomo
       enableTraefikRouter: false
       image: rancher/k3s:v1.28.2-k3s1
+      args:
+        - "--port"
+        - "80:80@loadbalancer"
 ```
 
 ### Ownbrew

--- a/k3d-io/k3d/command.go
+++ b/k3d-io/k3d/command.go
@@ -230,6 +230,7 @@ func (c *Command) up(ctx context.Context, r *readline.Readline) error {
 	).
 		Env(c.kubectl.Cluster(name).Env("")).
 		Args(args...).
+		Args(clusterCfg.Args...).
 		Args(r.AdditionalArgs()...).
 		Args(r.AdditionalFlags()...).
 		Run()


### PR DESCRIPTION
feat(k3d): allow passing extra cluster args from config

Added support for ConfigCluster.Args in Command.up(), so that users can
define additional k3d cluster arguments (e.g. extra --port mappings)
directly in their YAML config.

Example:

```
k3d:
  charts:
    path: path/to/k3d
    prefix: shared-
  registry:
    name: foomo-registry
    port: 12345
  clusters:
    local:
      port: 9443
      alias: foomo
      enableTraefikRouter: false
      image: rancher/k3s:v1.28.2-k3s1
      args:
        - "--port"
        - "80:80@loadbalancer"
```