### PR TITLE
feat(sshtunnel): add provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ schema:
 		--resolve ./stern/stern/config.schema.json \
 		--resolve ./usebruno/bruno/config.schema.json \
 		--resolve ./webdriverio/webdriverio/config.schema.json \
+		--resolve ./sshtunnel/config.schema.json \
 		--without-id \
 		> config.schema.json
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -7,103 +7,103 @@
       "required": [ "version" ],
       "properties": {
         "az": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1azure~1az~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1azure~1az~1config"
         },
         "beam": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1foomo~1beam~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1foomo~1beam~1config"
         },
         "bruno": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1usebruno~1bruno~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1usebruno~1bruno~1config"
         },
         "cdktf": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1hashicorp~1cdktf~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1hashicorp~1cdktf~1config"
         },
         "cloudflared": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1cloudflare~1cloudflared~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1cloudflare~1cloudflared~1config"
         },
         "doctl": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1digitalocean~1doctl~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1digitalocean~1doctl~1config"
         },
         "docusaurus": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1facebook~1docusaurus~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1facebook~1docusaurus~1config"
         },
         "etcd": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1etcd-io~1etcd~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1etcd-io~1etcd~1config"
         },
         "gcloud": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1google~1gcloud~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1google~1gcloud~1config"
         },
         "gocontentful": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1foomo~1gocontentful~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1foomo~1gocontentful~1config"
         },
         "harbor": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1goharbor~1harbor~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1goharbor~1harbor~1config"
         },
         "hygen": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1jondot~1hygen~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1jondot~1hygen~1config"
         },
         "k3d": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1k3d-io~1k3d~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1k3d-io~1k3d~1config"
         },
         "k6": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1grafana~1k6~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1grafana~1k6~1config"
         },
         "kubectl": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1kubernets~1kubectl~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1kubernets~1kubectl~1config"
         },
         "kubeforward": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1kubernets~1kubeforward~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1kubernets~1kubeforward~1config"
         },
         "licensefinder": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1pivotal~1licensefinder~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1pivotal~1licensefinder~1config"
         },
         "migrate": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1golang-migrate~1migrate~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1golang-migrate~1migrate~1config"
         },
         "mkcert": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1filosottile~1mkcert~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1filosottile~1mkcert~1config"
         },
         "onepassword": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1onepassword~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1onepassword~1config"
         },
         "open": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1arbitrary~1open~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1arbitrary~1open~1config"
         },
         "pulumi-azure": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1pulumi~1pulumi~1azure~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1pulumi~1pulumi~1azure~1config"
         },
         "pulumi-gcloud": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1pulumi~1pulumi~1gcloud~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1pulumi~1pulumi~1gcloud~1config"
         },
         "rclone": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1rclone~1rclone~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1rclone~1rclone~1config"
         },
         "sesamy": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1foomo~1sesamy~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1foomo~1sesamy~1config"
         },
         "slack": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1slack-go~1slack~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1slack-go~1slack~1config"
         },
         "sqlc": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1sqlc-dev~1sqlc~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1sqlc-dev~1sqlc~1config"
         },
         "squadron": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1foomo~1squadron~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1foomo~1squadron~1config"
         },
         "stackit": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1stackitcloud~1stackit~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1stackitcloud~1stackit~1config"
         },
         "stern": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1stern~1stern~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1stern~1stern~1config"
         },
         "task": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1arbitrary~1task~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1arbitrary~1task~1config"
         },
         "teleport": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1gravitational~1teleport~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1gravitational~1teleport~1config"
         },
         "terragrunt": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1gruntwork-io~1terragrunt~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1gruntwork-io~1terragrunt~1config"
         },
         "version": {
           "description": "Version of the schema",
@@ -111,22 +111,22 @@
           "pattern": "^[0-9]\\.[0-9]$"
         },
         "webdriverio": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config"
         },
         "zip": {
-          "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1arbitrary~1zip~1config"
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1arbitrary~1zip~1config"
         }
       },
       "additionalProperties": false
     },
     "https://github.com/foomo/posh-providers/arbitrary/open/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1arbitrary~1open~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1arbitrary~1open~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1arbitrary~1open~1config/$defs/ConfigRouter"
+            "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1arbitrary~1open~1config/$defs/ConfigRouter"
           }
         },
         "ConfigRoute": {
@@ -139,7 +139,7 @@
             },
             "basicAuth": {
               "description": "Basic authentication secret",
-              "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1arbitrary~1open~1config/$defs/Secret"
+              "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1arbitrary~1open~1config/$defs/Secret"
             },
             "path": {
               "description": "Route path",
@@ -149,7 +149,7 @@
               "description": "Child routes",
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1arbitrary~1open~1config/$defs/ConfigRoute"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1arbitrary~1open~1config/$defs/ConfigRoute"
               }
             }
           },
@@ -167,7 +167,7 @@
               "description": "Router Child routes",
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1arbitrary~1open~1config/$defs/ConfigRoute"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1arbitrary~1open~1config/$defs/ConfigRoute"
               }
             },
             "url": {
@@ -200,12 +200,12 @@
     },
     "https://github.com/foomo/posh-providers/arbitrary/task/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1arbitrary~1task~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1arbitrary~1task~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1arbitrary~1task~1config/$defs/Task"
+            "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1arbitrary~1task~1config/$defs/Task"
           }
         },
         "Task": {
@@ -241,7 +241,7 @@
     },
     "https://github.com/foomo/posh-providers/arbitrary/zip/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1arbitrary~1zip~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1arbitrary~1zip~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
@@ -250,7 +250,7 @@
             "credentials": {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1arbitrary~1zip~1config/$defs/Secret"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1arbitrary~1zip~1config/$defs/Secret"
               }
             }
           },
@@ -279,7 +279,7 @@
     },
     "https://github.com/foomo/posh-providers/azure/az/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1azure~1az~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1azure~1az~1config/$defs/Config",
       "$defs": {
         "Artifactory": {
           "type": "object",
@@ -311,18 +311,53 @@
         },
         "Config": {
           "type": "object",
-          "required": [ "configPath", "subscriptions" ],
+          "required": [
+            "configPath",
+            "tenantId",
+            "subscriptions",
+            "servicePrincipals"
+          ],
           "properties": {
             "configPath": {
               "description": "Config path",
               "type": "string"
             },
+            "servicePrincipals": {
+              "description": "Authentication service principals",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1azure~1az~1config/$defs/ServicePrincipal"
+              }
+            },
             "subscriptions": {
               "description": "Subscription configurations",
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1azure~1az~1config/$defs/Subscription"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1azure~1az~1config/$defs/Subscription"
               }
+            },
+            "tenantId": {
+              "description": "Tenant id",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "ServicePrincipal": {
+          "type": "object",
+          "required": [ "tenantId", "clientId", "clientSecret" ],
+          "properties": {
+            "clientId": {
+              "description": "Application client id",
+              "type": "string"
+            },
+            "clientSecret": {
+              "description": "Application password",
+              "type": "string"
+            },
+            "tenantId": {
+              "description": "Tenant id",
+              "type": "string"
             }
           },
           "additionalProperties": false
@@ -334,13 +369,13 @@
             "artifactories": {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1azure~1az~1config/$defs/Artifactory"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1azure~1az~1config/$defs/Artifactory"
               }
             },
             "clusters": {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1azure~1az~1config/$defs/Cluster"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1azure~1az~1config/$defs/Cluster"
               }
             },
             "name": {
@@ -353,7 +388,7 @@
     },
     "https://github.com/foomo/posh-providers/cloudflare/cloudflared/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1cloudflare~1cloudflared~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1cloudflare~1cloudflared~1config/$defs/Config",
       "$defs": {
         "Access": {
           "type": "object",
@@ -378,7 +413,7 @@
             "access": {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1cloudflare~1cloudflared~1config/$defs/Access"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1cloudflare~1cloudflared~1config/$defs/Access"
               }
             },
             "path": {
@@ -391,7 +426,7 @@
     },
     "https://github.com/foomo/posh-providers/digitalocean/doctl/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1digitalocean~1doctl~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1digitalocean~1doctl~1config/$defs/Config",
       "$defs": {
         "Cluster": {
           "type": "object",
@@ -410,7 +445,7 @@
             "clusters": {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1digitalocean~1doctl~1config/$defs/Cluster"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1digitalocean~1doctl~1config/$defs/Cluster"
               }
             },
             "configPath": {
@@ -423,7 +458,7 @@
     },
     "https://github.com/foomo/posh-providers/etcd-io/etcd/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1etcd-io~1etcd~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1etcd-io~1etcd~1config/$defs/Config",
       "$defs": {
         "Cluster": {
           "type": "object",
@@ -454,7 +489,7 @@
             "clusters": {
               "type": "array",
               "items": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1etcd-io~1etcd~1config/$defs/Cluster"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1etcd-io~1etcd~1config/$defs/Cluster"
               }
             },
             "configPath": {
@@ -467,7 +502,7 @@
     },
     "https://github.com/foomo/posh-providers/facebook/docusaurus/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1facebook~1docusaurus~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1facebook~1docusaurus~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
@@ -508,7 +543,7 @@
     },
     "https://github.com/foomo/posh-providers/filosottile/mkcert/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1filosottile~1mkcert~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1filosottile~1mkcert~1config/$defs/Config",
       "$defs": {
         "Certificate": {
           "type": "object",
@@ -536,7 +571,7 @@
             "certificates": {
               "type": "array",
               "items": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1filosottile~1mkcert~1config/$defs/Certificate"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1filosottile~1mkcert~1config/$defs/Certificate"
               }
             }
           },
@@ -546,7 +581,7 @@
     },
     "https://github.com/foomo/posh-providers/foomo/beam/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1foomo~1beam~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1foomo~1beam~1config/$defs/Config",
       "$defs": {
         "Cluster": {
           "type": "object",
@@ -556,7 +591,7 @@
               "type": "string"
             },
             "kubeconfig": {
-              "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1foomo~1beam~1config/$defs/Secret"
+              "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1foomo~1beam~1config/$defs/Secret"
             },
             "port": {
               "type": "integer"
@@ -571,13 +606,13 @@
             "clusters": {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1foomo~1beam~1config/$defs/Cluster"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1foomo~1beam~1config/$defs/Cluster"
               }
             },
             "databases": {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1foomo~1beam~1config/$defs/Database"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1foomo~1beam~1config/$defs/Database"
               }
             }
           },
@@ -619,7 +654,7 @@
     },
     "https://github.com/foomo/posh-providers/foomo/gocontentful/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1foomo~1gocontentful~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1foomo~1gocontentful~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
@@ -647,7 +682,7 @@
     },
     "https://github.com/foomo/posh-providers/foomo/sesamy/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1foomo~1sesamy~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1foomo~1sesamy~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
@@ -662,7 +697,7 @@
     },
     "https://github.com/foomo/posh-providers/foomo/squadron/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1foomo~1squadron~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1foomo~1squadron~1config/$defs/Config",
       "$defs": {
         "Cluster": {
           "type": "object",
@@ -698,7 +733,7 @@
               "description": "Cluster configurations",
               "type": "array",
               "items": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1foomo~1squadron~1config/$defs/Cluster"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1foomo~1squadron~1config/$defs/Cluster"
               }
             },
             "path": {
@@ -712,7 +747,7 @@
     },
     "https://github.com/foomo/posh-providers/goharbor/harbor/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1goharbor~1harbor~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1goharbor~1harbor~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
@@ -734,7 +769,7 @@
     },
     "https://github.com/foomo/posh-providers/golang-migrate/migrate/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1golang-migrate~1migrate~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1golang-migrate~1migrate~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
@@ -759,7 +794,7 @@
     },
     "https://github.com/foomo/posh-providers/google/gcloud/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1google~1gcloud~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1google~1gcloud~1config/$defs/Config",
       "$defs": {
         "Account": {
           "type": "object",
@@ -769,7 +804,7 @@
               "type": "string"
             },
             "key": {
-              "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1google~1gcloud~1config/$defs/Secret"
+              "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1google~1gcloud~1config/$defs/Secret"
             },
             "name": {
               "type": "string"
@@ -803,13 +838,13 @@
             "accounts": {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1google~1gcloud~1config/$defs/Account"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1google~1gcloud~1config/$defs/Account"
               }
             },
             "clusters": {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1google~1gcloud~1config/$defs/Cluster"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1google~1gcloud~1config/$defs/Cluster"
               }
             },
             "configPath": {
@@ -841,7 +876,7 @@
     },
     "https://github.com/foomo/posh-providers/grafana/k6/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1grafana~1k6~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1grafana~1k6~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
@@ -850,7 +885,7 @@
             "envs": {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1grafana~1k6~1config/$defs/Env"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1grafana~1k6~1config/$defs/Env"
               }
             },
             "path": {
@@ -869,11 +904,18 @@
     },
     "https://github.com/foomo/posh-providers/gravitational/teleport/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1gravitational~1teleport~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1gravitational~1teleport~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
-          "required": [ "path", "labels", "hostname", "kubernetes", "apps", "database" ],
+          "required": [
+            "path",
+            "labels",
+            "hostname",
+            "kubernetes",
+            "apps",
+            "database"
+          ],
           "properties": {
             "apps": {
               "type": "object",
@@ -885,13 +927,13 @@
               }
             },
             "database": {
-              "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1gravitational~1teleport~1config/$defs/Database"
+              "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1gravitational~1teleport~1config/$defs/Database"
             },
             "hostname": {
               "type": "string"
             },
             "kubernetes": {
-              "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1gravitational~1teleport~1config/$defs/Kubernetes"
+              "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1gravitational~1teleport~1config/$defs/Kubernetes"
             },
             "labels": {
               "type": "object",
@@ -932,7 +974,7 @@
     },
     "https://github.com/foomo/posh-providers/gruntwork-io/terragrunt/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1gruntwork-io~1terragrunt~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1gruntwork-io~1terragrunt~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
@@ -951,7 +993,7 @@
     },
     "https://github.com/foomo/posh-providers/hashicorp/cdktf/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1hashicorp~1cdktf~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1hashicorp~1cdktf~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
@@ -970,7 +1012,7 @@
     },
     "https://github.com/foomo/posh-providers/jondot/hygen/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1jondot~1hygen~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1jondot~1hygen~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
@@ -986,23 +1028,23 @@
     },
     "https://github.com/foomo/posh-providers/k3d-io/k3d/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1k3d-io~1k3d~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1k3d-io~1k3d~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
           "required": [ "charts", "registry", "clusters" ],
           "properties": {
             "charts": {
-              "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1k3d-io~1k3d~1config/$defs/ConfigCharts"
+              "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1k3d-io~1k3d~1config/$defs/ConfigCharts"
             },
             "clusters": {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1k3d-io~1k3d~1config/$defs/ConfigCluster"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1k3d-io~1k3d~1config/$defs/ConfigCluster"
               }
             },
             "registry": {
-              "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1k3d-io~1k3d~1config/$defs/ConfigRegistry"
+              "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1k3d-io~1k3d~1config/$defs/ConfigRegistry"
             }
           },
           "additionalProperties": false
@@ -1022,7 +1064,13 @@
         },
         "ConfigCluster": {
           "type": "object",
-          "required": [ "alias", "image", "port", "enableTraefikRouter", "args" ],
+          "required": [
+            "alias",
+            "image",
+            "port",
+            "enableTraefikRouter",
+            "args"
+          ],
           "properties": {
             "alias": {
               "description": "K3d cluster name",
@@ -1067,7 +1115,7 @@
     },
     "https://github.com/foomo/posh-providers/kubernets/kubectl/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1kubernets~1kubectl~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1kubernets~1kubectl~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
@@ -1083,17 +1131,23 @@
     },
     "https://github.com/foomo/posh-providers/kubernets/kubeforward/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1kubernets~1kubeforward~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1kubernets~1kubeforward~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1kubernets~1kubeforward~1config/$defs/PortForward"
+            "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1kubernets~1kubeforward~1config/$defs/PortForward"
           }
         },
         "PortForward": {
           "type": "object",
-          "required": [ "cluster", "namespace", "description", "target", "port" ],
+          "required": [
+            "cluster",
+            "namespace",
+            "description",
+            "target",
+            "port"
+          ],
           "properties": {
             "description": {
               "description": "Optional description",
@@ -1122,7 +1176,7 @@
     },
     "https://github.com/foomo/posh-providers/onepassword/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1onepassword~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1onepassword~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
@@ -1141,7 +1195,7 @@
     },
     "https://github.com/foomo/posh-providers/pivotal/licensefinder/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1pivotal~1licensefinder~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1pivotal~1licensefinder~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
@@ -1166,7 +1220,7 @@
     },
     "https://github.com/foomo/posh-providers/pulumi/pulumi/azure/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1pulumi~1pulumi~1azure~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1pulumi~1pulumi~1azure~1config/$defs/Config",
       "$defs": {
         "Backend": {
           "type": "object",
@@ -1186,7 +1240,7 @@
               "type": "string"
             },
             "passphrase": {
-              "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1pulumi~1pulumi~1azure~1config/$defs/Secret"
+              "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1pulumi~1pulumi~1azure~1config/$defs/Secret"
             },
             "resourceGroup": {
               "type": "string"
@@ -1207,7 +1261,7 @@
             "backends": {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1pulumi~1pulumi~1azure~1config/$defs/Backend"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1pulumi~1pulumi~1azure~1config/$defs/Backend"
               }
             },
             "configPath": {
@@ -1242,7 +1296,7 @@
     },
     "https://github.com/foomo/posh-providers/pulumi/pulumi/gcloud/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1pulumi~1pulumi~1gcloud~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1pulumi~1pulumi~1gcloud~1config/$defs/Config",
       "$defs": {
         "Backend": {
           "type": "object",
@@ -1255,7 +1309,7 @@
               "type": "string"
             },
             "passphrase": {
-              "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1pulumi~1pulumi~1gcloud~1config/$defs/Secret"
+              "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1pulumi~1pulumi~1gcloud~1config/$defs/Secret"
             },
             "project": {
               "type": "string"
@@ -1270,7 +1324,7 @@
             "backends": {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1pulumi~1pulumi~1gcloud~1config/$defs/Backend"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1pulumi~1pulumi~1gcloud~1config/$defs/Backend"
               }
             },
             "configPath": {
@@ -1305,7 +1359,7 @@
     },
     "https://github.com/foomo/posh-providers/rclone/rclone/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1rclone~1rclone~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1rclone~1rclone~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
@@ -1324,7 +1378,7 @@
     },
     "https://github.com/foomo/posh-providers/slack-go/slack/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1slack-go~1slack~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1slack-go~1slack~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
@@ -1337,12 +1391,12 @@
               }
             },
             "token": {
-              "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1slack-go~1slack~1config/$defs/Secret"
+              "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1slack-go~1slack~1config/$defs/Secret"
             },
             "webhooks": {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1slack-go~1slack~1config/$defs/Secret"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1slack-go~1slack~1config/$defs/Secret"
               }
             }
           },
@@ -1371,7 +1425,7 @@
     },
     "https://github.com/foomo/posh-providers/sqlc-dev/sqlc/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1sqlc-dev~1sqlc~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1sqlc-dev~1sqlc~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
@@ -1390,7 +1444,7 @@
     },
     "https://github.com/foomo/posh-providers/stackitcloud/stackit/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1stackitcloud~1stackit~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1stackitcloud~1stackit~1config/$defs/Config",
       "$defs": {
         "Cluster": {
           "type": "object",
@@ -1409,7 +1463,7 @@
             "projects": {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1stackitcloud~1stackit~1config/$defs/Project"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1stackitcloud~1stackit~1config/$defs/Project"
               }
             }
           },
@@ -1425,7 +1479,7 @@
             "clusters": {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1stackitcloud~1stackit~1config/$defs/Cluster"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1stackitcloud~1stackit~1config/$defs/Cluster"
               }
             }
           },
@@ -1435,7 +1489,7 @@
     },
     "https://github.com/foomo/posh-providers/stern/stern/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1stern~1stern~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1stern~1stern~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
@@ -1444,7 +1498,7 @@
             "queries": {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1stern~1stern~1config/$defs/Query"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1stern~1stern~1config/$defs/Query"
               }
             }
           },
@@ -1457,7 +1511,7 @@
             "queries": {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1stern~1stern~1config/$defs/Query"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1stern~1stern~1config/$defs/Query"
               }
             },
             "query": {
@@ -1473,7 +1527,7 @@
     },
     "https://github.com/foomo/posh-providers/usebruno/bruno/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1usebruno~1bruno~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1usebruno~1bruno~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
@@ -1489,14 +1543,14 @@
     },
     "https://github.com/foomo/posh-providers/webdriverio/webdriverio/config": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config/$defs/Config",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config/$defs/Config",
       "$defs": {
         "Config": {
           "type": "object",
           "required": [ "dirs", "modes", "sites", "secrets", "browserStack" ],
           "properties": {
             "browserStack": {
-              "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config/$defs/Secret"
+              "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config/$defs/Secret"
             },
             "dirs": {
               "type": "array",
@@ -1505,16 +1559,16 @@
               }
             },
             "modes": {
-              "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config/$defs/ConfigModes"
+              "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config/$defs/ConfigModes"
             },
             "secrets": {
               "type": "object",
               "additionalProperties": {
-                "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config/$defs/Secret"
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config/$defs/Secret"
               }
             },
             "sites": {
-              "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config/$defs/ConfigSites"
+              "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config/$defs/ConfigSites"
             }
           },
           "additionalProperties": false
@@ -1524,7 +1578,7 @@
           "required": [ "auth", "domain" ],
           "properties": {
             "auth": {
-              "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config/$defs/Secret"
+              "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config/$defs/Secret"
             },
             "domain": {
               "type": "string"
@@ -1535,7 +1589,7 @@
         "ConfigEnvs": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config/$defs/ConfigEnv"
+            "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config/$defs/ConfigEnv"
           }
         },
         "ConfigMode": {
@@ -1554,13 +1608,13 @@
         "ConfigModes": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config/$defs/ConfigMode"
+            "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config/$defs/ConfigMode"
           }
         },
         "ConfigSites": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/$defs/https%3A~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config/$defs/ConfigEnvs"
+            "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1webdriverio~1webdriverio~1config/$defs/ConfigEnvs"
           }
         },
         "Secret": {

--- a/sshtunnel/README.md
+++ b/sshtunnel/README.md
@@ -1,0 +1,163 @@
+SSH Tunnel Manager
+==================
+
+A CLI tool to manage multiple SSH tunnels via configuration, supporting password-based authentication, SSH-key authentication, 1Password integration, and optional sudo access.
+
+Features
+--------
+
+*   Define multiple SSH tunnels in .posh.yaml configuration file.
+
+*   Support for:
+
+    *   1Password CLI for secure password retrieval
+
+    *   Plaintext passwords or Paths
+
+    *   SSH private key authentication
+
+*   Automatic check if tunnels are running.
+
+*   Automatic check if local port not in use.
+
+*   Automatic check if target proxy port is open.
+
+*   Start and stop tunnels with ease.
+
+*   Optional sudo escalation per tunnel.
+
+
+Config
+-------------
+
+Define your tunnels in .posh.yaml file:
+
+```yaml
+sshTunnel:
+  socketsPath: devops/config/ssh
+  tempDir: "devops/tmp" # used to store tmp keys if privateKey is a op vault
+  tunnels:
+    - name: "cluster-prod-tunnel"
+      localPort: 10443
+      targetProxyHost: "192.168.181.96"
+      targetProxyPort: 8001
+      targetUsername: "administrator"
+      targetHost: "78.85.45.111"
+      targetAuth:
+        type: sshpass
+        password: <% op "account" "vault" "item" "field" %> # or plaintext
+    - name: "harbor-prod-tunnel"
+      sudo: true
+      localPort: 443
+      targetProxyHost: "core.harbor.domain"
+      targetProxyPort: 443
+      targetUsername: "administrator"
+      targetHost: "98.85.56.25"
+      targetAuth:
+        type: key
+        privateKey: "path/to/your/private_key" # or op vault
+```
+
+
+### Field Description
+
+| Field                   | Type     | Description                                                                       |
+| ----------------------- | -------- | --------------------------------------------------------------------------------- |
+| `socketsDir`            | string   | Directory where SSH control socket and config files will be stored.               |
+| `tempDir`               | string   | Directory where temp keys/config files will be stored.                                 |
+| `tunnels`               | list     | List of tunnel configurations.                                                    |
+| `name`                  | string   | Unique tunnel name.                                                               |
+| `sudo`                  | bool     | Whether to run SSH commands with `sudo`.                                          |
+| `localPort`             | int      | Local port to bind the tunnel.                                                    |
+| `targetProxyHost`       | string   | Hostname or IP of the internal target service.                                    |
+| `targetProxyPort`       | int      | Port of the internal target service.                                              |
+| `targetUsername`        | string   | SSH username for the remote host.                                                 |
+| `targetHost`            | string   | SSH target host (hostname or IP).                                                 |
+| `targetAuth`            | object   | Authentication method configuration.                                              |
+| `targetAuth.type`       | enum     | `"sshpass"`, `"key"`.                                                             |
+| `targetAuth.password`   | string   | Password string or 1Password CLI template (required for `"sshpass"`).             |
+| `targetAuth.privateKey` | string   | Path to SSH private key or 1Password CLI template (required for `"key"`).         |
+
+Authentication
+--------------
+
+*   **1Password CLI (op)**: securely fetch passwords from your vault.
+
+*   **Plaintext**: specify the password or private key path directly in the YAML (not recommended for production).
+
+
+Example 1Password YAML entry:
+
+```yaml
+targetAuth:
+  type: sshpass
+  password: <% op "account" "vault" "item" "field" %>
+```
+The `targetAuth` is optional and if it's not defined in YAML file the prompt will ask you for the credential
+
+Installation
+---------
+Define a new command in `".posh/internal/plugin.go"`
+
+```go
+type Plugin struct {
+	l         log.Logger
+	cache     cache.Cache
+	op        *onepassword.OnePassword
+	sshTunnel *sshtunnel.SSHTunnel
+	commands  command.Commands
+}
+```
+
+Then in the constructor
+```go
+func New(l log.Logger) (plugin.Plugin, error) {
+	inst := &Plugin{
+		l:        l,
+		cache:    &cache.MemoryCache{},
+		commands: command.Commands{},
+	}
+
+	if value, err := onepassword.New(l, inst.cache); err != nil {
+		return nil, errors.Wrap(err, "failed to create onepassword")
+	} else {
+		inst.op = value
+	}
+
+	if value, err := sshtunnel.New(l); err != nil {
+		return nil, errors.Wrap(err, "failed to create sshTunnel")
+	} else {
+		inst.sshTunnel = value
+	}
+
+	// add commands
+	inst.commands.MustAdd(onepassword.NewCommand(l, inst.op))
+	inst.commands.MustAdd(sshtunnel.NewCommand(l, inst.sshTunnel, inst.cache, inst.op))
+
+	return inst, nil
+}
+```
+Now you need to rebuild the shell with `make shell.rebuild`
+
+CLI Usage
+---------
+```bash
+sshtunnel <tunnel-name> <cmd>
+```
+
+### Cmds
+
+| Command | Description                      |
+| ------- | -------------------------------- |
+| `start` | Starts the specified SSH tunnel. |
+| `stop`  | Stops the specified SSH tunnel.  |
+
+
+Notes
+-----
+
+*   SSH tunnels use **control sockets** for master connections.
+
+*   Any missing or inactive tunnel is automatically reported as “not running”.
+
+*   Running SSH commands are quiet by default unless debugging is enabled.

--- a/sshtunnel/command.go
+++ b/sshtunnel/command.go
@@ -1,0 +1,326 @@
+package sshtunnel
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/foomo/posh-providers/onepassword"
+	"github.com/foomo/posh/pkg/cache"
+	"github.com/foomo/posh/pkg/command/tree"
+	"github.com/foomo/posh/pkg/log"
+	"github.com/foomo/posh/pkg/prompt/goprompt"
+	"github.com/foomo/posh/pkg/readline"
+	"github.com/foomo/posh/pkg/shell"
+	"github.com/foomo/posh/pkg/util/suggests"
+	"github.com/pkg/errors"
+)
+
+type (
+	Command struct {
+		l           log.Logger
+		cache       cache.Namespace
+		name        string
+		commandTree tree.Root
+		op          *onepassword.OnePassword
+		sshTunnel   *SSHTunnel
+	}
+	CommandOption func(*Command)
+)
+
+// ------------------------------------------------------------------------------------------------
+// ~ Options
+// ------------------------------------------------------------------------------------------------
+
+func CommandWithName(v string) CommandOption {
+	return func(o *Command) {
+		o.name = v
+	}
+}
+
+// ------------------------------------------------------------------------------------------------
+// ~ Constructor
+// ------------------------------------------------------------------------------------------------
+
+func NewCommand(l log.Logger, sshTunnel *SSHTunnel, cache cache.Cache, op *onepassword.OnePassword, opts ...CommandOption) (*Command, error) {
+	inst := &Command{
+		l:         l.Named("SSHTunnel"),
+		name:      "sshtunnel",
+		op:        op,
+		sshTunnel: sshTunnel,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(inst)
+		}
+	}
+
+	inst.l = l.Named(inst.name)
+	inst.cache = cache.Get(inst.name)
+
+	tunnelsValues := func(ctx context.Context, r *readline.Readline) []goprompt.Suggest {
+		var ret []string
+		ret = append(ret, inst.sshTunnel.cfg.TunnelNames()...)
+		return suggests.List(ret)
+	}
+
+	cmdsValues := func(ctx context.Context, r *readline.Readline) []goprompt.Suggest {
+		return []goprompt.Suggest{
+			{Text: "start", Description: "Start SSH-Tunnel"},
+			{Text: "stop", Description: "Stop SSH-Tunnel"},
+		}
+	}
+
+	inst.commandTree = tree.New(&tree.Node{
+		Name:        inst.name,
+		Description: "SSH-Tunnels Managament",
+		Nodes: tree.Nodes{
+			{
+				Name:        "tunnel",
+				Description: "Tunnel name",
+				Values:      tunnelsValues,
+				Nodes: tree.Nodes{
+					{
+						Name:        "cmd",
+						Description: "Command type",
+						Values:      cmdsValues,
+						Execute:     inst.execute,
+					},
+				},
+			},
+		},
+	})
+
+	return inst, nil
+}
+
+// ------------------------------------------------------------------------------------------------
+// ~ Public methods
+// ------------------------------------------------------------------------------------------------
+
+func (c *Command) Name() string {
+	return c.commandTree.Node().Name
+}
+
+func (c *Command) Description() string {
+	return c.commandTree.Node().Description
+}
+
+func (c *Command) Complete(ctx context.Context, r *readline.Readline) []goprompt.Suggest {
+	return c.commandTree.Complete(ctx, r)
+}
+
+func (c *Command) Validate(ctx context.Context, r *readline.Readline) error {
+	switch {
+	case r.Args().LenIs(0):
+		return errors.New("missing [tunnel] argument")
+	case r.Args().LenIs(1):
+		return errors.New("missing [cmd] argument")
+	}
+	return nil
+}
+
+func (c *Command) Execute(ctx context.Context, r *readline.Readline) error {
+	return c.commandTree.Execute(ctx, r)
+}
+
+func (c *Command) Help(ctx context.Context, r *readline.Readline) string {
+	return c.commandTree.Help(ctx, r)
+}
+
+// ------------------------------------------------------------------------------------------------
+// ~ Execution
+// ------------------------------------------------------------------------------------------------
+func (c *Command) execute(ctx context.Context, r *readline.Readline) error {
+	tunnelName, cmd := r.Args()[0], r.Args()[1]
+
+	tunnelConfig, ok := c.sshTunnel.Tunnel(tunnelName)
+	if !ok {
+		return errors.Errorf("tunnel configuration %q not found", tunnelName)
+	}
+
+	tempDir := c.sshTunnel.TempDir()
+	socketsDir := c.sshTunnel.SocketsDir()
+	if err := os.MkdirAll(socketsDir, 0o755); err != nil {
+		return errors.Wrap(err, "failed to create SSH sockets directory")
+	}
+	socketsFile := fmt.Sprintf("%s/%s", socketsDir, tunnelName)
+
+	sudo := ""
+	if tunnelConfig.Sudo {
+		sudo = "sudo"
+	}
+
+	var cmdStr string
+	var sshpass string
+
+	switch cmd {
+	case "start":
+		if c.sshTunnel.IsTunnelRunning(ctx, tunnelName) {
+			c.l.Infof("Tunnel %s is already running", tunnelName)
+			return nil
+		}
+
+		if c.sshTunnel.IsLocalPortInUse(ctx, tunnelName) {
+			return errors.Errorf("bind [127.0.0.1]:%d: Address already in use", tunnelConfig.LocalPort)
+		}
+
+		var (
+			targetAuthPassword   string
+			targetAuthPrivateKey string
+			cleanup              func()
+			err                  error
+		)
+		if tunnelConfig.TargetAuth.Type == "sshpass" {
+			targetAuthPassword, _, err = c.resolveSSHCredential(ctx, tunnelConfig.TargetAuth.Password, tempDir, "sshpass")
+			if err != nil {
+				return err
+			}
+		}
+
+		if tunnelConfig.TargetAuth.Type == "key" {
+			targetAuthPrivateKey, cleanup, err = c.resolveSSHCredential(ctx, tunnelConfig.TargetAuth.PrivateKey, tempDir, "key")
+			if cleanup != nil {
+				defer cleanup()
+			}
+			if err != nil {
+				return err
+			}
+		}
+
+		if !c.sshTunnel.IsTargetProxyPortOpen(ctx, tunnelName, targetAuthPassword, targetAuthPrivateKey) {
+			return errors.Errorf(
+				"cannot reach target proxy port %d at %s from host %s. Make sure the port is open.",
+				tunnelConfig.TargetProxyPort,
+				tunnelConfig.TargetProxyHost,
+				tunnelConfig.TargetHost,
+			)
+		}
+
+		if targetAuthPassword != "" {
+			sshpass = fmt.Sprintf("sshpass -p %s", targetAuthPassword)
+		}
+		cmdStr = fmt.Sprintf(
+			"%s %s ssh",
+			sudo,
+			sshpass,
+		)
+
+		sh := shell.New(ctx, c.l, cmdStr).
+			Args("-M").
+			Args("-S", socketsFile).
+			Args("-fnNT").
+			Args("-L", fmt.Sprintf(
+				"%d:%s:%d",
+				tunnelConfig.LocalPort,
+				tunnelConfig.TargetProxyHost,
+				tunnelConfig.TargetProxyPort,
+			)).
+			Args(fmt.Sprintf("%s@%s", tunnelConfig.TargetUsername, tunnelConfig.TargetHost))
+
+		if targetAuthPrivateKey != "" {
+			sh.Args("-i", targetAuthPrivateKey)
+		}
+
+		if err := sh.Run(); err != nil {
+			return errors.Wrap(err, "failed to start ssh tunnel")
+		}
+
+		c.l.Successf("Tunnel %s started successfully", tunnelName)
+
+	case "stop":
+		if !c.sshTunnel.IsTunnelRunning(ctx, tunnelName) {
+			c.l.Infof("Tunnel %s is not running", tunnelName)
+			return nil
+		}
+
+		cmdStr = fmt.Sprintf(
+			"%s ssh",
+			sudo,
+		)
+
+		sh := shell.New(ctx, c.l, cmdStr).
+			Args("-S", socketsFile).
+			Args("-O", "exit").
+			Args(fmt.Sprintf("%s@%s", tunnelConfig.TargetUsername, tunnelConfig.TargetHost))
+
+		if err := sh.Run(); err != nil {
+			return errors.Wrap(err, "failed to stop ssh tunnel")
+		}
+
+		c.l.Successf("Tunnel %s stopped successfully", tunnelName)
+
+	default:
+		return errors.Errorf("unknown command: %s", cmd)
+	}
+
+	return nil
+}
+
+// resolveSSHCredential resolves SSH credentials for a tunnel.
+// - For "sshpass": returns the password.
+// - For "key": returns a file path to an existing key or writes content to a temp file.
+// Supports resolving secrets from 1Password.
+func (c *Command) resolveSSHCredential(ctx context.Context, value, tempDir, authType string) (string, func(), error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		switch authType {
+		case "sshpass":
+			return "", nil, errors.New("password field is required for authType sshpass")
+		case "key":
+			return "", nil, errors.New("privateKey field is required for authType key")
+		}
+		return "", nil, nil
+	}
+	isFrom1Password := false
+
+	if strings.HasPrefix(value, "<% op") {
+		isFrom1Password = true
+		if c.op == nil {
+			return "", nil, errors.New("1Password client not available")
+		}
+		if ok, _ := c.op.IsAuthenticated(ctx); !ok {
+			c.l.Info("Missing 1Password session, please login")
+			if err := c.op.SignIn(ctx); err != nil {
+				return "", nil, errors.Wrap(err, "failed to sign in to 1Password")
+			}
+		}
+		secretBytes, err := c.op.Render(ctx, value)
+		if err != nil {
+			return "", nil, errors.Wrap(err, "failed to render 1Password secret")
+		}
+		value = strings.TrimSpace(string(secretBytes))
+	}
+
+	switch authType {
+	case "sshpass":
+		return value, nil, nil
+
+	case "key":
+		// Check if the value is a path to an existing file
+		if !isFrom1Password {
+			if _, err := os.Stat(value); err == nil {
+				return value, nil, nil
+			} else if os.IsNotExist(err) {
+				return "", nil, errors.Wrap(err, "private key file does not exist")
+			}
+		}
+		// otherwise treat value as key content and write it to a temp file
+		tmpFile, err := os.CreateTemp(tempDir, "sshkey-*")
+		if err != nil {
+			return "", nil, errors.Wrap(err, "failed to create temporary key file")
+		}
+		defer tmpFile.Close()
+
+		if _, err := tmpFile.Write([]byte(value)); err != nil {
+			return "", nil, errors.Wrap(err, "failed to write private key to temporary file")
+		}
+
+		cleanup := func() { os.Remove(tmpFile.Name()) }
+		return tmpFile.Name(), cleanup, nil
+
+	default:
+		return "", nil, errors.Errorf("unknown tunnel auth type: %s", authType)
+	}
+}

--- a/sshtunnel/command.go
+++ b/sshtunnel/command.go
@@ -150,7 +150,7 @@ func (c *Command) execute(ctx context.Context, r *readline.Readline) error {
 	if err := os.MkdirAll(socketsDir, 0o755); err != nil {
 		return errors.Wrap(err, "failed to create SSH sockets directory")
 	}
-	socketsFile := fmt.Sprintf("%s/%s", socketsDir, tunnelName)
+	socketFile := fmt.Sprintf("%s/%s", socketsDir, tunnelName)
 
 	sudo := ""
 	if tunnelConfig.Sudo {
@@ -214,7 +214,7 @@ func (c *Command) execute(ctx context.Context, r *readline.Readline) error {
 
 		sh := shell.New(ctx, c.l, cmdStr).
 			Args("-M").
-			Args("-S", socketsFile).
+			Args("-S", socketFile).
 			Args("-fnNT").
 			Args("-L", fmt.Sprintf(
 				"%d:%s:%d",
@@ -246,7 +246,7 @@ func (c *Command) execute(ctx context.Context, r *readline.Readline) error {
 		)
 
 		sh := shell.New(ctx, c.l, cmdStr).
-			Args("-S", socketsFile).
+			Args("-S", socketFile).
 			Args("-O", "exit").
 			Args(fmt.Sprintf("%s@%s", tunnelConfig.TargetUsername, tunnelConfig.TargetHost))
 
@@ -299,10 +299,10 @@ func (c *Command) resolveSSHCredential(ctx context.Context, value, tempDir, auth
 	}
 
 	switch authType {
-	case "sshpass":
+	case AuthTypePass:
 		return value, nil, nil
 
-	case "key":
+	case AuthTypeKey:
 		// Check if the value is a path to an existing file
 		if !isFrom1Password {
 			if _, err := os.Stat(value); err == nil {

--- a/sshtunnel/command.go
+++ b/sshtunnel/command.go
@@ -306,6 +306,9 @@ func (c *Command) resolveSSHCredential(ctx context.Context, value, tempDir, auth
 		// Check if the value is a path to an existing file
 		if !isFrom1Password {
 			if _, err := os.Stat(value); err == nil {
+				if err := os.Chmod(value, 0600); err != nil {
+					return "", nil, errors.Wrap(err, "failed to set permissions on private key")
+				}
 				return value, nil, nil
 			} else if os.IsNotExist(err) {
 				return "", nil, errors.Wrap(err, "private key file does not exist")

--- a/sshtunnel/config.go
+++ b/sshtunnel/config.go
@@ -1,0 +1,28 @@
+package sshtunnel
+
+type (
+	Config struct {
+		SocketsDir string   `json:"socketsDir" yaml:"socketsDir"`
+		TempDir    string   `json:"tempDir" yaml:"tempDir"`
+		Tunnels    []Tunnel `json:"tunnels" yaml:"tunnels"`
+	}
+)
+
+// Tunnel returns a tunnel by name
+func (c Config) Tunnel(name string) (Tunnel, bool) {
+	for _, t := range c.Tunnels {
+		if t.Name == name {
+			return t, true
+		}
+	}
+	return Tunnel{}, false
+}
+
+// TunnelNames returns all configured tunnel names
+func (c Config) TunnelNames() []string {
+	var ret []string
+	for _, tunnel := range c.Tunnels {
+		ret = append(ret, tunnel.Name)
+	}
+	return ret
+}

--- a/sshtunnel/config.schema.json
+++ b/sshtunnel/config.schema.json
@@ -43,9 +43,6 @@
       },
       "additionalProperties": false,
       "type": "object",
-      "required": [
-        "type"
-      ],
       "description": "TargetAuth holds authentication information for SSH Target Server"
     },
     "Tunnel": {
@@ -87,7 +84,6 @@
       "type": "object",
       "required": [
         "name",
-        "sudo",
         "localPort",
         "targetProxyHost",
         "targetProxyPort",

--- a/sshtunnel/config.schema.json
+++ b/sshtunnel/config.schema.json
@@ -1,61 +1,100 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/your-org/posh-providers/sshTunnel/config",
+  "$id": "https://github.com/foomo/posh-providers/sshtunnel/config",
   "$ref": "#/$defs/Config",
   "$defs": {
-    "TargetAuth": {
-      "type": "object",
+    "Config": {
       "properties": {
-        "type": {
-          "type": "string",
-          "enum": ["sshpass", "key"],
-          "description": "Authentication type: password or SSH key"
+        "socketsDir": {
+          "type": "string"
         },
-        "password": {
-          "type": "string",
-          "description": "Password for sshpass (plain or 1Password reference)"
+        "tempDir": {
+          "type": "string"
         },
-        "privateKey": {
-          "type": "string",
-          "description": "Path to private key or 1Password reference"
+        "tunnels": {
+          "items": {
+            "$ref": "#/$defs/Tunnel"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,
-      "required": ["type"],
-      "if": {
-        "properties": { "type": { "const": "sshpass" } }
-      },
-      "then": { "required": ["password"] },
-      "else": { "required": ["privateKey"] }
-    },
-    "Tunnel": {
       "type": "object",
-      "properties": {
-        "name": { "type": "string", "description": "Tunnel name" },
-        "sudo": { "type": "boolean", "description": "Run tunnel with sudo", "default": false },
-        "localPort": { "type": "integer", "description": "Local port to bind" },
-        "targetProxyHost": { "type": "string", "description": "Host of the target proxy" },
-        "targetProxyPort": { "type": "integer", "description": "Target proxy port" },
-        "targetUsername": { "type": "string", "description": "Username for SSH connection" },
-        "targetHost": { "type": "string", "description": "Target SSH host" },
-        "targetAuth": { "$ref": "#/$defs/TargetAuth" }
-      },
-      "required": ["name", "localPort", "targetProxyHost", "targetProxyPort", "targetUsername", "targetHost", "targetAuth"],
-      "additionalProperties": false
+      "required": [
+        "socketsDir",
+        "tempDir",
+        "tunnels"
+      ]
     },
-    "Config": {
-      "type": "object",
+    "TargetAuth": {
       "properties": {
-        "socketsPath": { "type": "string", "description": "Path for socket files" },
-        "tempDir": { "type": "string", "description": "Directory to store temporary keys" },
-        "tunnels": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/Tunnel" },
-          "description": "List of SSH tunnels"
+        "type": {
+          "type": "string",
+          "description": "Auth method: \"sshpass\", \"key\","
+        },
+        "password": {
+          "type": "string",
+          "description": "Password-based authentication (optional)"
+        },
+        "privateKey": {
+          "type": "string",
+          "description": "Private key path (optional)"
         }
       },
-      "required": ["socketsPath", "tempDir", "tunnels"],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "description": "TargetAuth holds authentication information for SSH Target Server"
+    },
+    "Tunnel": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique tunnel name"
+        },
+        "sudo": {
+          "type": "boolean",
+          "description": "Whether this tunnel requires sudo privileges"
+        },
+        "localPort": {
+          "type": "integer",
+          "description": "Local port to bind"
+        },
+        "targetProxyHost": {
+          "type": "string",
+          "description": "Target server proxy host"
+        },
+        "targetProxyPort": {
+          "type": "integer",
+          "description": "Target server proxy port"
+        },
+        "targetUsername": {
+          "type": "string",
+          "description": "SSH server username"
+        },
+        "targetHost": {
+          "type": "string",
+          "description": "SSH server hostname or IP"
+        },
+        "targetAuth": {
+          "$ref": "#/$defs/TargetAuth",
+          "description": "Authentication details (password, private key)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "sudo",
+        "localPort",
+        "targetProxyHost",
+        "targetProxyPort",
+        "targetUsername",
+        "targetHost",
+        "targetAuth"
+      ]
     }
   }
 }

--- a/sshtunnel/config.schema.json
+++ b/sshtunnel/config.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/your-org/posh-providers/sshTunnel/config",
+  "$ref": "#/$defs/Config",
+  "$defs": {
+    "TargetAuth": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["sshpass", "key"],
+          "description": "Authentication type: password or SSH key"
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for sshpass (plain or 1Password reference)"
+        },
+        "privateKey": {
+          "type": "string",
+          "description": "Path to private key or 1Password reference"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["type"],
+      "if": {
+        "properties": { "type": { "const": "sshpass" } }
+      },
+      "then": { "required": ["password"] },
+      "else": { "required": ["privateKey"] }
+    },
+    "Tunnel": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string", "description": "Tunnel name" },
+        "sudo": { "type": "boolean", "description": "Run tunnel with sudo", "default": false },
+        "localPort": { "type": "integer", "description": "Local port to bind" },
+        "targetProxyHost": { "type": "string", "description": "Host of the target proxy" },
+        "targetProxyPort": { "type": "integer", "description": "Target proxy port" },
+        "targetUsername": { "type": "string", "description": "Username for SSH connection" },
+        "targetHost": { "type": "string", "description": "Target SSH host" },
+        "targetAuth": { "$ref": "#/$defs/TargetAuth" }
+      },
+      "required": ["name", "localPort", "targetProxyHost", "targetProxyPort", "targetUsername", "targetHost", "targetAuth"],
+      "additionalProperties": false
+    },
+    "Config": {
+      "type": "object",
+      "properties": {
+        "socketsPath": { "type": "string", "description": "Path for socket files" },
+        "tempDir": { "type": "string", "description": "Directory to store temporary keys" },
+        "tunnels": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Tunnel" },
+          "description": "List of SSH tunnels"
+        }
+      },
+      "required": ["socketsPath", "tempDir", "tunnels"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/sshtunnel/config_test.go
+++ b/sshtunnel/config_test.go
@@ -1,0 +1,40 @@
+package sshtunnel_test
+
+import (
+	"encoding/json"
+	"os"
+	"path"
+	"testing"
+
+	testingx "github.com/foomo/go/testing"
+	tagx "github.com/foomo/go/testing/tag"
+	"github.com/foomo/posh-providers/arbitrary/task"
+	"github.com/invopop/jsonschema"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig(t *testing.T) {
+	t.Parallel()
+	testingx.Tags(t, tagx.Short)
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	reflector := new(jsonschema.Reflector)
+	require.NoError(t, reflector.AddGoComments("github.com/foomo/posh-providers/sshtunnel", "./"))
+	schema := reflector.Reflect(&task.Config{})
+	actual, err := json.MarshalIndent(schema, "", "  ")
+	require.NoError(t, err)
+
+	filename := path.Join(cwd, "config.schema.json")
+	expected, err := os.ReadFile(filename)
+	if !errors.Is(err, os.ErrNotExist) {
+		require.NoError(t, err)
+	}
+
+	if !assert.Equal(t, string(expected), string(actual)) {
+		require.NoError(t, os.WriteFile(filename, actual, 0600))
+	}
+}

--- a/sshtunnel/config_test.go
+++ b/sshtunnel/config_test.go
@@ -8,7 +8,7 @@ import (
 
 	testingx "github.com/foomo/go/testing"
 	tagx "github.com/foomo/go/testing/tag"
-	"github.com/foomo/posh-providers/arbitrary/task"
+	"github.com/foomo/posh-providers/sshtunnel"
 	"github.com/invopop/jsonschema"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -24,7 +24,7 @@ func TestConfig(t *testing.T) {
 
 	reflector := new(jsonschema.Reflector)
 	require.NoError(t, reflector.AddGoComments("github.com/foomo/posh-providers/sshtunnel", "./"))
-	schema := reflector.Reflect(&task.Config{})
+	schema := reflector.Reflect(&sshtunnel.Config{})
 	actual, err := json.MarshalIndent(schema, "", "  ")
 	require.NoError(t, err)
 

--- a/sshtunnel/sshtunel.go
+++ b/sshtunnel/sshtunel.go
@@ -106,19 +106,19 @@ func (s *SSHTunnel) IsTargetProxyPortOpen(ctx context.Context, name, targetAuthP
 	}
 
 	cmdStr := fmt.Sprintf("%s ssh", sshpass)
-
 	ncCmdStr := fmt.Sprintf("nc -z -w2 %s %d", tunnel.TargetProxyHost, tunnel.TargetProxyPort)
 
 	// Build the shell command
 	sh := shell.New(ctx, s.l, cmdStr).
-		Args(fmt.Sprintf("%s@%s", tunnel.TargetUsername, tunnel.TargetHost)).
-		Args(ncCmdStr)
+		Args(fmt.Sprintf("%s@%s", tunnel.TargetUsername, tunnel.TargetHost))
 
 	if targetAuthPrivateKey != "" {
 		sh.Args("-i", targetAuthPrivateKey)
 	}
 
-	sh.Quiet()
+	sh.Args(ncCmdStr).
+		Quiet()
+
 	return sh.Run() == nil
 }
 

--- a/sshtunnel/sshtunel.go
+++ b/sshtunnel/sshtunel.go
@@ -1,0 +1,135 @@
+package sshtunnel
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/foomo/posh/pkg/log"
+	"github.com/foomo/posh/pkg/shell"
+	"github.com/spf13/viper"
+)
+
+// SSHTunnel command
+type (
+	SSHTunnel struct {
+		l         log.Logger
+		cfg       Config
+		configKey string
+	}
+	Option func(*SSHTunnel) error
+)
+
+// ------------------------------------------------------------------------------------------------
+// ~ Options
+// ------------------------------------------------------------------------------------------------
+
+func CommandWithConfigKey(v string) Option {
+	return func(o *SSHTunnel) error {
+		o.configKey = v
+		return nil
+	}
+}
+
+// ------------------------------------------------------------------------------------------------
+// ~ Constructor
+// ------------------------------------------------------------------------------------------------
+
+// New command
+func New(l log.Logger, opts ...Option) (*SSHTunnel, error) {
+	inst := &SSHTunnel{
+		l:         l,
+		configKey: "sshTunnel",
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			if err := opt(inst); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if err := viper.UnmarshalKey(inst.configKey, &inst.cfg); err != nil {
+		return nil, err
+	}
+
+	return inst, nil
+}
+
+func (s *SSHTunnel) Config() Config {
+	return s.cfg
+}
+
+func (s *SSHTunnel) SocketsDir() string {
+	return s.cfg.SocketsDir
+}
+
+func (s *SSHTunnel) TempDir() string {
+	return s.cfg.TempDir
+}
+
+func (s *SSHTunnel) Tunnel(name string) (Tunnel, bool) {
+	return s.cfg.Tunnel(name)
+}
+
+// IsTunnelRunning checks if the SSH tunnel with the given name is currently active.
+func (s *SSHTunnel) IsTunnelRunning(ctx context.Context, name string) bool {
+	tunnel, _ := s.Tunnel(name)
+	sudo := ""
+	if tunnel.Sudo {
+		sudo = "sudo"
+	}
+
+	cmdStr := ""
+	cmdStr = fmt.Sprintf(
+		"%s ssh",
+		sudo,
+	)
+
+	sh := shell.New(ctx, s.l, cmdStr).
+		Args("-S", fmt.Sprintf("%s/%s", s.SocketsDir(), tunnel.Name)).
+		Args("-O", "check").
+		Args(fmt.Sprintf("%s@%s", tunnel.TargetUsername, tunnel.TargetHost)).
+		Quiet()
+
+	if err := sh.Run(); err != nil {
+		return false
+	}
+
+	return true
+}
+
+// IsTargetProxyPortOpen checks if the targetHost:targetProxyPort is open.
+func (s *SSHTunnel) IsTargetProxyPortOpen(ctx context.Context, name, targetAuthPassword, targetAuthPrivateKey string) bool {
+	tunnel, _ := s.Tunnel(name)
+
+	sshpass := ""
+	if targetAuthPassword != "" {
+		sshpass = fmt.Sprintf("sshpass -p %s", targetAuthPassword)
+	}
+
+	cmdStr := fmt.Sprintf("%s ssh", sshpass)
+
+	ncStr := fmt.Sprintf("nc -z -w2 %s %d", tunnel.TargetProxyHost, tunnel.TargetProxyPort)
+
+	// Build the shell command
+	sh := shell.New(ctx, s.l, cmdStr).
+		Args(fmt.Sprintf("%s@%s", tunnel.TargetUsername, tunnel.TargetHost)).
+		Args(ncStr)
+
+	if targetAuthPrivateKey != "" {
+		sh.Args("-i", targetAuthPrivateKey)
+	}
+
+	sh.Quiet()
+	return sh.Run() == nil
+}
+
+// IsLocalPortInUse checks if the LocalPort is in already use.
+func (s *SSHTunnel) IsLocalPortInUse(ctx context.Context, name string) bool {
+	tunnel, _ := s.Tunnel(name)
+	cmdStr := fmt.Sprintf("nc -z -w2 127.0.0.1 %d", tunnel.LocalPort)
+
+	sh := shell.New(ctx, s.l, cmdStr)
+	sh.Quiet()
+	err := sh.Run()
+	return err == nil
+}

--- a/sshtunnel/sshtunel.go
+++ b/sshtunnel/sshtunel.go
@@ -78,8 +78,7 @@ func (s *SSHTunnel) IsTunnelRunning(ctx context.Context, name string) bool {
 		sudo = "sudo"
 	}
 
-	cmdStr := ""
-	cmdStr = fmt.Sprintf(
+	cmdStr := fmt.Sprintf(
 		"%s ssh",
 		sudo,
 	)

--- a/sshtunnel/sshtunel.go
+++ b/sshtunnel/sshtunel.go
@@ -107,12 +107,12 @@ func (s *SSHTunnel) IsTargetProxyPortOpen(ctx context.Context, name, targetAuthP
 
 	cmdStr := fmt.Sprintf("%s ssh", sshpass)
 
-	ncStr := fmt.Sprintf("nc -z -w2 %s %d", tunnel.TargetProxyHost, tunnel.TargetProxyPort)
+	ncCmdStr := fmt.Sprintf("nc -z -w2 %s %d", tunnel.TargetProxyHost, tunnel.TargetProxyPort)
 
 	// Build the shell command
 	sh := shell.New(ctx, s.l, cmdStr).
 		Args(fmt.Sprintf("%s@%s", tunnel.TargetUsername, tunnel.TargetHost)).
-		Args(ncStr)
+		Args(ncCmdStr)
 
 	if targetAuthPrivateKey != "" {
 		sh.Args("-i", targetAuthPrivateKey)

--- a/sshtunnel/tunnel.go
+++ b/sshtunnel/tunnel.go
@@ -1,0 +1,32 @@
+package sshtunnel
+
+type (
+	Tunnel struct {
+		// Unique tunnel name
+		Name string `json:"name" yaml:"name"`
+		// Whether this tunnel requires sudo privileges
+		Sudo bool `json:"sudo" yaml:"sudo"`
+		// Local port to bind
+		LocalPort int `json:"localPort" yaml:"localPort"`
+		// Target server proxy host
+		TargetProxyHost string `json:"targetProxyHost" yaml:"targetProxyHost"`
+		// Target server proxy port
+		TargetProxyPort int `json:"targetProxyPort" yaml:"targetProxyPort"`
+		// SSH server username
+		TargetUsername string `json:"targetUsername" yaml:"targetUsername"`
+		// SSH server hostname or IP
+		TargetHost string `json:"targetHost" yaml:"targetHost"`
+		// Authentication details (password, private key)
+		TargetAuth TargetAuth `json:"targetAuth" yaml:"targetAuth"`
+	}
+
+	// TargetAuth holds authentication information for SSH Target Server
+	TargetAuth struct {
+		// Auth method: "sshpass", "key",
+		Type string `json:"type" yaml:"type"`
+		// Password-based authentication (optional)
+		Password string `json:"password,omitempty" yaml:"password,omitempty"`
+		// Private key path (optional)
+		PrivateKey string `json:"privateKey,omitempty" yaml:"privateKey,omitempty"`
+	}
+)

--- a/sshtunnel/tunnel.go
+++ b/sshtunnel/tunnel.go
@@ -5,7 +5,7 @@ type (
 		// Unique tunnel name
 		Name string `json:"name" yaml:"name"`
 		// Whether this tunnel requires sudo privileges
-		Sudo bool `json:"sudo" yaml:"sudo"`
+		Sudo bool `json:"sudo,omitempty" yaml:"sudo,omitempty"`
 		// Local port to bind
 		LocalPort int `json:"localPort" yaml:"localPort"`
 		// Target server proxy host
@@ -17,13 +17,13 @@ type (
 		// SSH server hostname or IP
 		TargetHost string `json:"targetHost" yaml:"targetHost"`
 		// Authentication details (password, private key)
-		TargetAuth TargetAuth `json:"targetAuth" yaml:"targetAuth"`
+		TargetAuth TargetAuth `json:"targetAuth,omitzero" yaml:"targetAuth,omitempty"`
 	}
 
 	// TargetAuth holds authentication information for SSH Target Server
 	TargetAuth struct {
 		// Auth method: "sshpass", "key",
-		Type string `json:"type" yaml:"type"`
+		Type string `json:"type,omitempty" yaml:"type,omitempty"`
 		// Password-based authentication (optional)
 		Password string `json:"password,omitempty" yaml:"password,omitempty"`
 		// Private key path (optional)


### PR DESCRIPTION
This PR introduces a new SSH Tunnel provider command to manage multiple SSH tunnels via configuration. Key features include:

* **Tunnel Management:** Start and stop SSH tunnels based on a declarative YAML configuration.
* **Authentication Support:**

  * Password-based authentication (including 1Password integration)
  * SSH key authentication (including 1Password integration)
* **1Password Integration:** Resolve passwords or private keys directly from 1Password vaults.
* **Optional Sudo:** Ability to run tunnels with `sudo` when required.
* **Port Conflict Handling:** Checks if the local port is already in use before starting a tunnel.
* **Temporary Key Handling:** Creates temporary files for private keys obtained from 1Password and cleans them up after use.
* **CLI Integration:** Fully integrated into the CLI with autocompletion and command tree support.

This provider enables secure and automated management of SSH tunnels for multiple environments, supporting both developer and CI/CD workflows.

For more information, please read the README.md.