### PR TITLE
feat(hashicorp/terraform): add terraform provider

### DIFF
--- a/hashicorp/terraform/README.md
+++ b/hashicorp/terraform/README.md
@@ -1,0 +1,33 @@
+# POSH terraform provider
+
+## Usage
+
+### Plugin
+
+```go
+func New(l log.Logger) (plugin.Plugin, error) {
+	// ...
+  inst.commands.MustAdd(terraform.NewCommand(l, inst.cache))
+	// ...
+}
+```
+
+### Config
+
+```yaml
+terraform:
+  path: path/to/terraform/workspaces
+  subscriptions:
+    my-workspace:
+      id: 00000000-0000-0000-0000-000000000000
+      backend:
+        resourceGroupName: my-rg
+        storageAccountName: mystorageaccount
+        containerName: tfstate
+  servicePrincipals:
+    my-sp:
+      tenantId: 00000000-0000-0000-0000-000000000000
+      clientId: 00000000-0000-0000-0000-000000000000
+      clientSecret: my-secret
+      subscriptionId: 00000000-0000-0000-0000-000000000000
+```

--- a/hashicorp/terraform/command.go
+++ b/hashicorp/terraform/command.go
@@ -1,0 +1,441 @@
+package terraform
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+
+	"github.com/foomo/posh/pkg/cache"
+	"github.com/foomo/posh/pkg/command/tree"
+	"github.com/foomo/posh/pkg/log"
+	"github.com/foomo/posh/pkg/prompt/goprompt"
+	"github.com/foomo/posh/pkg/readline"
+	"github.com/foomo/posh/pkg/shell"
+	"github.com/foomo/posh/pkg/util/suggests"
+	"github.com/spf13/viper"
+)
+
+type (
+	Command struct {
+		l           log.Logger
+		cfg         Config
+		name        string
+		cache       cache.Namespace
+		configKey   string
+		commandTree tree.Root
+	}
+	CommandOption func(*Command)
+)
+
+// ------------------------------------------------------------------------------------------------
+// ~ Options
+// ------------------------------------------------------------------------------------------------
+
+func CommandWithName(v string) CommandOption {
+	return func(o *Command) {
+		o.name = v
+	}
+}
+
+func WithConfigKey(v string) CommandOption {
+	return func(o *Command) {
+		o.configKey = v
+	}
+}
+
+// ------------------------------------------------------------------------------------------------
+// ~ Constructor
+// ------------------------------------------------------------------------------------------------
+
+func NewCommand(l log.Logger, cache cache.Cache, opts ...CommandOption) (*Command, error) {
+	inst := &Command{
+		l:         l.Named("terraform"),
+		name:      "terraform",
+		configKey: "terraform",
+		cache:     cache.Get("terraform"),
+	}
+
+	for _, opt := range opts {
+		if opt != nil {
+			opt(inst)
+		}
+	}
+
+	if err := viper.UnmarshalKey(inst.configKey, &inst.cfg); err != nil {
+		return nil, err
+	}
+
+	inst.commandTree = tree.New(&tree.Node{
+		Name:        inst.name,
+		Description: "Run terraform commands",
+		Nodes: tree.Nodes{
+			{
+				Name:        "workspace",
+				Values:      inst.getWorkspaces,
+				Description: "Workspace to operate on",
+				Nodes: tree.Nodes{
+					{
+						Name:        "init",
+						Description: "Prepare your working directory for other commands",
+						Flags:       inst.addAuthFlags,
+						Execute:     inst.execute,
+					},
+					{
+						Name:        "validate",
+						Description: "Check whether the configuration is valid",
+						Flags:       inst.addAuthFlags,
+						Execute:     inst.execute,
+					},
+					{
+						Name:        "plan",
+						Description: "Show changes required by the current configuration",
+						Args: tree.Args{
+							{
+								Name:        "target",
+								Description: "Limit to a specific module or resource (optional)",
+								Optional:    true,
+								Repeat:      true,
+								Suggest: func(ctx context.Context, t tree.Root, r *readline.Readline) []goprompt.Suggest {
+									return suggests.List(inst.cfg.WorkspaceTargets(r.Args().At(0)))
+								},
+							},
+						},
+						Flags: func(ctx context.Context, r *readline.Readline, fs *readline.FlagSets) error {
+							if err := inst.addAuthFlags(ctx, r, fs); err != nil {
+								return err
+							}
+
+							fs.Default().Bool("refresh-only", false, "Select the 'refresh only' planning mode")
+							fs.Default().String("var-file", "", "Load variable values from a file")
+
+							return nil
+						},
+						Execute: inst.execute,
+					},
+					{
+						Name:        "apply",
+						Description: "Create or update infrastructure",
+						Args: tree.Args{
+							{
+								Name:        "target",
+								Description: "Limit to a specific module or resource (optional)",
+								Optional:    true,
+								Repeat:      true,
+								Suggest: func(ctx context.Context, t tree.Root, r *readline.Readline) []goprompt.Suggest {
+									return suggests.List(inst.cfg.WorkspaceTargets(r.Args().At(0)))
+								},
+							},
+						},
+						Flags: func(ctx context.Context, r *readline.Readline, fs *readline.FlagSets) error {
+							if err := inst.addAuthFlags(ctx, r, fs); err != nil {
+								return err
+							}
+
+							fs.Default().Bool("auto-approve", false, "Skip interactive approval")
+							fs.Default().Bool("refresh-only", false, "Select the 'refresh only' planning mode")
+							fs.Default().String("var-file", "", "Load variable values from a file")
+
+							return nil
+						},
+						Execute: inst.execute,
+					},
+					{
+						Name:        "destroy",
+						Description: "Destroy previously-created infrastructure",
+						Args: tree.Args{
+							{
+								Name:        "target",
+								Description: "Limit to a specific module or resource (optional)",
+								Optional:    true,
+								Repeat:      true,
+								Suggest: func(ctx context.Context, t tree.Root, r *readline.Readline) []goprompt.Suggest {
+									return suggests.List(inst.cfg.WorkspaceTargets(r.Args().At(0)))
+								},
+							},
+						},
+						Flags: func(ctx context.Context, r *readline.Readline, fs *readline.FlagSets) error {
+							if err := inst.addAuthFlags(ctx, r, fs); err != nil {
+								return err
+							}
+
+							fs.Default().Bool("auto-approve", false, "Skip interactive approval")
+							fs.Default().String("var-file", "", "Load variable values from a file")
+
+							return nil
+						},
+						Execute: inst.execute,
+					},
+					{
+						Name:        "refresh",
+						Description: "Update the state to match remote systems",
+						Flags:       inst.addAuthFlags,
+						Execute:     inst.execute,
+					},
+					{
+						Name:        "output",
+						Description: "Show output values from your root module",
+						Args: tree.Args{
+							{
+								Name:        "name",
+								Description: "Output name (optional)",
+								Optional:    true,
+							},
+						},
+						Flags: func(ctx context.Context, r *readline.Readline, fs *readline.FlagSets) error {
+							if err := inst.addAuthFlags(ctx, r, fs); err != nil {
+								return err
+							}
+
+							fs.Default().Bool("raw", false, "Print the raw string directly")
+							fs.Default().Bool("json", false, "Output in JSON format")
+
+							return nil
+						},
+						Execute: inst.execute,
+					},
+					{
+						Name:        "import",
+						Description: "Associate existing infrastructure with a Terraform resource",
+						Args: tree.Args{
+							{
+								Name:        "address",
+								Description: "Resource address to import into",
+							},
+							{
+								Name:        "id",
+								Description: "Resource ID to import",
+							},
+						},
+						Flags:   inst.addAuthFlags,
+						Execute: inst.execute,
+					},
+					{
+						Name:        "state",
+						Description: "Advanced state management",
+						Nodes: tree.Nodes{
+							{
+								Name:        "list",
+								Description: "List resources in the state",
+								Flags:       inst.addAuthFlags,
+								Execute:     inst.executeState,
+							},
+							{
+								Name:        "show",
+								Description: "Show a resource in the state",
+								Args: tree.Args{
+									{
+										Name:        "address",
+										Description: "Resource address to show",
+									},
+								},
+								Flags:   inst.addAuthFlags,
+								Execute: inst.executeState,
+							},
+							{
+								Name:        "mv",
+								Description: "Move an item in the state",
+								Args: tree.Args{
+									{
+										Name:        "source",
+										Description: "Source address",
+									},
+									{
+										Name:        "destination",
+										Description: "Destination address",
+									},
+								},
+								Flags:   inst.addAuthFlags,
+								Execute: inst.executeState,
+							},
+							{
+								Name:        "rm",
+								Description: "Remove instances from the state",
+								Args: tree.Args{
+									{
+										Name:        "address",
+										Description: "Resource address to remove",
+									},
+								},
+								Flags:   inst.addAuthFlags,
+								Execute: inst.executeState,
+							},
+						},
+					},
+					{
+						Name:        "unlock",
+						Description: "Unlock a stuck lock on the current workspace",
+						Args: tree.Args{
+							{
+								Name:        "lockId",
+								Description: "Terraform state lock ID",
+							},
+						},
+						Flags: func(ctx context.Context, r *readline.Readline, fs *readline.FlagSets) error {
+							if err := inst.addAuthFlags(ctx, r, fs); err != nil {
+								return err
+							}
+
+							fs.Default().Bool("force", false, "Don't ask for input confirmation")
+
+							return nil
+						},
+						Execute: inst.unlock,
+					},
+				},
+			},
+		},
+	})
+
+	return inst, nil
+}
+
+// ------------------------------------------------------------------------------------------------
+// ~ Public methods
+// ------------------------------------------------------------------------------------------------
+
+func (c *Command) Name() string {
+	return c.commandTree.Node().Name
+}
+
+func (c *Command) Description() string {
+	return c.commandTree.Node().Description
+}
+
+func (c *Command) Complete(ctx context.Context, r *readline.Readline) []goprompt.Suggest {
+	return c.commandTree.Complete(ctx, r)
+}
+
+func (c *Command) Execute(ctx context.Context, r *readline.Readline) error {
+	return c.commandTree.Execute(ctx, r)
+}
+
+func (c *Command) Validate(ctx context.Context, r *readline.Readline) error {
+	if _, err := exec.LookPath("terraform"); err != nil {
+		c.l.Print()
+		return errors.New("missing terraform executable")
+	}
+
+	return nil
+}
+
+func (c *Command) Help(ctx context.Context, r *readline.Readline) string {
+	return c.commandTree.Help(ctx, r)
+}
+
+// ------------------------------------------------------------------------------------------------
+// ~ Private methods
+// ------------------------------------------------------------------------------------------------
+
+func (c *Command) addAuthFlags(ctx context.Context, r *readline.Readline, fs *readline.FlagSets) error {
+	fs.Internal().String("service-principal", "", "Service principal to use for authentication")
+	return fs.Internal().SetValues("service-principal", c.cfg.ServicePrincipalNames()...)
+}
+
+func (c *Command) authEnv(r *readline.Readline, workspace string) ([]string, error) {
+	sp, err := r.FlagSets().Internal().GetString("service-principal")
+	if err != nil {
+		return nil, err
+	}
+
+	if sp != "" {
+		spc, err := c.cfg.ServicePrincipal(sp)
+		if err != nil {
+			return nil, err
+		}
+
+		return []string{
+			"ARM_TENANT_ID=" + spc.TenantID,
+			"ARM_CLIENT_ID=" + spc.ClientID,
+			"ARM_CLIENT_SECRET=" + spc.ClientSecret,
+			"ARM_SUBSCRIPTION_ID=" + spc.SubscriptionID,
+		}, nil
+	}
+
+	// User account (az CLI) auth — inject subscription ID if configured
+	if sub, err := c.cfg.Subscription(workspace); err == nil {
+		return []string{"ARM_SUBSCRIPTION_ID=" + sub.ID}, nil
+	}
+
+	return nil, nil
+}
+
+func (c *Command) execute(ctx context.Context, r *readline.Readline) error {
+	workspace := r.Args().At(0)
+	command := r.Args().At(1)
+
+	env, err := c.authEnv(r, workspace)
+	if err != nil {
+		return err
+	}
+
+	cmd := shell.New(ctx, c.l, "terraform", command).
+		Dir(c.cfg.WorkspacePath(workspace)).
+		Args(r.FlagSets().Default().Visited().Args()...).
+		Args(r.AdditionalArgs()...).
+		Args(r.AdditionalFlags()...).
+		Env(env...)
+
+	switch command {
+	case "apply", "plan", "destroy":
+		// Positional args are module/resource targets selected from autocomplete;
+		// they must be passed as -target= flags, not as bare positional args.
+		for _, target := range r.Args().From(2) {
+			cmd = cmd.Args("-target=" + target)
+		}
+	case "init":
+		cmd = cmd.Args(c.cfg.BackendInitArgs(workspace)...)
+	default:
+		cmd = cmd.Args(r.Args().From(2)...)
+	}
+
+	return cmd.Run()
+}
+
+func (c *Command) executeState(ctx context.Context, r *readline.Readline) error {
+	workspace := r.Args().At(0)
+	subcommand := r.Args().At(2)
+
+	env, err := c.authEnv(r, workspace)
+	if err != nil {
+		return err
+	}
+
+	return shell.New(ctx, c.l, "terraform", "state", subcommand).
+		Dir(c.cfg.WorkspacePath(workspace)).
+		Args(r.Args().From(3)...).
+		Args(r.FlagSets().Default().Visited().Args()...).
+		Args(r.AdditionalArgs()...).
+		Args(r.AdditionalFlags()...).
+		Env(env...).
+		Run()
+}
+
+func (c *Command) unlock(ctx context.Context, r *readline.Readline) error {
+	workspace := r.Args().At(0)
+	lockID := r.Args().At(2)
+
+	env, err := c.authEnv(r, workspace)
+	if err != nil {
+		return err
+	}
+
+	return shell.New(ctx, c.l, "terraform", "force-unlock").
+		Dir(c.cfg.WorkspacePath(workspace)).
+		Args(r.FlagSets().Default().Visited().Args()...).
+		Args(lockID).
+		Args(r.AdditionalArgs()...).
+		Args(r.AdditionalFlags()...).
+		Env(env...).
+		Run()
+}
+
+func (c *Command) getWorkspaces(ctx context.Context, r *readline.Readline) []goprompt.Suggest {
+	return c.cache.GetSuggests("workspaces", func() any {
+		workspaces := c.cfg.WorkspaceNames()
+		if len(workspaces) == 0 {
+			c.l.Debug("no terraform workspaces found")
+		}
+
+		return suggests.List(workspaces)
+	})
+}

--- a/hashicorp/terraform/command.go
+++ b/hashicorp/terraform/command.go
@@ -351,12 +351,14 @@ func (c *Command) authEnv(r *readline.Readline, workspace string) ([]string, err
 		}, nil
 	}
 
-	// User account (az CLI) auth — inject subscription ID if configured
+	// No SP selected — let the provider use its default auth chain
+	// (CLI locally, managed identity on Azure VMs, OIDC in CI, etc.)
+	var env []string
 	if sub, err := c.cfg.Subscription(workspace); err == nil {
-		return []string{"ARM_SUBSCRIPTION_ID=" + sub.ID}, nil
+		env = append(env, "ARM_SUBSCRIPTION_ID="+sub.ID)
 	}
 
-	return nil, nil
+	return env, nil
 }
 
 func (c *Command) execute(ctx context.Context, r *readline.Readline) error {

--- a/hashicorp/terraform/config.base.json
+++ b/hashicorp/terraform/config.base.json
@@ -1,0 +1,12 @@
+{
+	"allOf": [
+		{
+			"type": "object",
+			"properties": {
+				"terraform": {
+					"$ref": "https://github.com/foomo/posh-providers/hashicorp/terraform"
+				}
+			}
+		}
+	]
+}

--- a/hashicorp/terraform/config.go
+++ b/hashicorp/terraform/config.go
@@ -1,0 +1,206 @@
+package terraform
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type Config struct {
+	Path              string                      `json:"path" yaml:"path"`
+	Subscriptions     map[string]Subscription     `json:"subscriptions" yaml:"subscriptions"`
+	ServicePrincipals map[string]ServicePrincipal `json:"servicePrincipals" yaml:"servicePrincipals"`
+}
+
+type Subscription struct {
+	// Azure subscription ID
+	ID string `json:"id" yaml:"id"`
+	// Backend state storage configuration
+	Backend Backend `json:"backend" yaml:"backend"`
+}
+
+type Backend struct {
+	// Resource group containing the storage account
+	ResourceGroupName string `json:"resourceGroupName" yaml:"resourceGroupName"`
+	// Storage account name
+	StorageAccountName string `json:"storageAccountName" yaml:"storageAccountName"`
+	// Blob container name
+	ContainerName string `json:"containerName" yaml:"containerName"`
+	// State file key (defaults to <workspace>.tfstate)
+	Key string `json:"key" yaml:"key"`
+}
+
+type ServicePrincipal struct {
+	// Tenant ID
+	TenantID string `json:"tenantId" yaml:"tenantId"`
+	// Application client ID
+	ClientID string `json:"clientId" yaml:"clientId"`
+	// Application client secret
+	ClientSecret string `json:"clientSecret" yaml:"clientSecret"`
+	// Azure subscription ID
+	SubscriptionID string `json:"subscriptionId" yaml:"subscriptionId"`
+}
+
+// ------------------------------------------------------------------------------------------------
+// ~ Public methods
+// ------------------------------------------------------------------------------------------------
+
+func (c Config) WorkspaceNames() []string {
+	var ret []string
+
+	entries, err := os.ReadDir(c.Path)
+	if err != nil {
+		return ret
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") || strings.HasPrefix(entry.Name(), "_") {
+			continue
+		}
+
+		// only include dirs that contain .tf files
+		if c.hasTFFiles(filepath.Join(c.Path, entry.Name())) {
+			ret = append(ret, entry.Name())
+		}
+	}
+
+	return ret
+}
+
+func (c Config) WorkspacePath(workspace string) string {
+	return filepath.Join(c.Path, workspace)
+}
+
+// BackendInitArgs returns -backend-config flags for `terraform init`.
+// Terraform's azurerm backend does not read storage config from env vars;
+// these values must be supplied as CLI flags.
+func (c Config) BackendInitArgs(workspace string) []string {
+	sub, ok := c.Subscriptions[workspace]
+	if !ok {
+		return nil
+	}
+
+	b := sub.Backend
+	if b.ResourceGroupName == "" || b.StorageAccountName == "" || b.ContainerName == "" {
+		return nil
+	}
+
+	key := b.Key
+	if key == "" {
+		key = workspace + ".tfstate"
+	}
+
+	return []string{
+		"-backend-config=resource_group_name=" + b.ResourceGroupName,
+		"-backend-config=storage_account_name=" + b.StorageAccountName,
+		"-backend-config=container_name=" + b.ContainerName,
+		"-backend-config=key=" + key,
+	}
+}
+
+// WorkspaceTargets parses all .tf files in the workspace directory and returns
+// a sorted list of addressable targets: "module.NAME" and "TYPE.NAME" for resources.
+func (c Config) WorkspaceTargets(workspace string) []string {
+	dir := c.WorkspacePath(workspace)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	moduleRe := regexp.MustCompile(`module\s+"([^"]+)"`)
+	resourceRe := regexp.MustCompile(`resource\s+"([^"]+)"\s+"([^"]+)"`)
+
+	seen := map[string]struct{}{}
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".tf") {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+
+		for _, m := range moduleRe.FindAllSubmatch(data, -1) {
+			seen["module."+string(m[1])] = struct{}{}
+		}
+
+		for _, m := range resourceRe.FindAllSubmatch(data, -1) {
+			seen[string(m[1])+"."+string(m[2])] = struct{}{}
+		}
+	}
+
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+
+	sort.Strings(out)
+
+	return out
+}
+
+func (c Config) Subscription(name string) (Subscription, error) {
+	value, ok := c.Subscriptions[name]
+	if !ok {
+		return Subscription{}, errors.Errorf("subscription not found: %s", name)
+	}
+
+	return value, nil
+}
+
+func (c Config) SubscriptionNames() []string {
+	keys := make([]string, 0, len(c.Subscriptions))
+	for k := range c.Subscriptions {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}
+
+func (c Config) ServicePrincipal(name string) (ServicePrincipal, error) {
+	value, ok := c.ServicePrincipals[name]
+	if !ok {
+		return ServicePrincipal{}, errors.Errorf("service principal not found: %s", name)
+	}
+
+	return value, nil
+}
+
+func (c Config) ServicePrincipalNames() []string {
+	keys := make([]string, 0, len(c.ServicePrincipals))
+	for k := range c.ServicePrincipals {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}
+
+// ------------------------------------------------------------------------------------------------
+// ~ Private methods
+// ------------------------------------------------------------------------------------------------
+
+func (c Config) hasTFFiles(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".tf") {
+			return true
+		}
+	}
+
+	return false
+}

--- a/hashicorp/terraform/config.schema.json
+++ b/hashicorp/terraform/config.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/foomo/posh-providers/hashicorp/terraform",
+  "$ref": "#/$defs/Config",
+  "$defs": {
+    "Backend": {
+      "properties": {
+        "resourceGroupName": {
+          "type": "string",
+          "description": "Resource group containing the storage account"
+        },
+        "storageAccountName": {
+          "type": "string",
+          "description": "Storage account name"
+        },
+        "containerName": {
+          "type": "string",
+          "description": "Blob container name"
+        },
+        "key": {
+          "type": "string",
+          "description": "State file key (defaults to \u003cworkspace\u003e.tfstate)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Config": {
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "subscriptions": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Subscription"
+          },
+          "type": "object"
+        },
+        "servicePrincipals": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ServicePrincipal"
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ServicePrincipal": {
+      "properties": {
+        "tenantId": {
+          "type": "string",
+          "description": "Tenant ID"
+        },
+        "clientId": {
+          "type": "string",
+          "description": "Application client ID"
+        },
+        "clientSecret": {
+          "type": "string",
+          "description": "Application client secret"
+        },
+        "subscriptionId": {
+          "type": "string",
+          "description": "Azure subscription ID"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Subscription": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Azure subscription ID"
+        },
+        "backend": {
+          "$ref": "#/$defs/Backend",
+          "description": "Backend state storage configuration"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/hashicorp/terraform/config_test.go
+++ b/hashicorp/terraform/config_test.go
@@ -1,0 +1,43 @@
+package terraform_test
+
+import (
+	"encoding/json"
+	"os"
+	"path"
+	"testing"
+
+	testingx "github.com/foomo/go/testing"
+	tagx "github.com/foomo/go/testing/tag"
+	"github.com/foomo/posh-providers/hashicorp/terraform"
+	"github.com/invopop/jsonschema"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig(t *testing.T) {
+	t.Parallel()
+	testingx.Tags(t, tagx.Short)
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+
+	reflector := new(jsonschema.Reflector)
+	reflector.RequiredFromJSONSchemaTags = true
+	require.NoError(t, reflector.AddGoComments("github.com/foomo/posh-providers/hashicorp/terraform", "./"))
+	schema := reflector.Reflect(&terraform.Config{})
+	schema.ID = "https://github.com/foomo/posh-providers/hashicorp/terraform"
+	actual, err := json.MarshalIndent(schema, "", "  ")
+	require.NoError(t, err)
+
+	filename := path.Join(cwd, "config.schema.json")
+
+	expected, err := os.ReadFile(filename)
+	if !errors.Is(err, os.ErrNotExist) {
+		require.NoError(t, err)
+	}
+
+	if !assert.Equal(t, string(expected), string(actual)) {
+		require.NoError(t, os.WriteFile(filename, actual, 0600))
+	}
+}

--- a/posh.schema.json
+++ b/posh.schema.json
@@ -15,6 +15,14 @@
     {
       "type": "object",
       "properties": {
+        "terraform": {
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1hashicorp~1terraform"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "properties": {
         "cdktf": {
           "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1hashicorp~1cdktf"
         }
@@ -438,6 +446,91 @@
             },
             "config": {
               "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "https://github.com/foomo/posh-providers/hashicorp/terraform": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1hashicorp~1terraform/$defs/Config",
+      "$defs": {
+        "Backend": {
+          "type": "object",
+          "properties": {
+            "resourceGroupName": {
+              "description": "Resource group containing the storage account",
+              "type": "string"
+            },
+            "storageAccountName": {
+              "description": "Storage account name",
+              "type": "string"
+            },
+            "containerName": {
+              "description": "Blob container name",
+              "type": "string"
+            },
+            "key": {
+              "description": "State file key (defaults to <workspace>.tfstate)",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Config": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "subscriptions": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1hashicorp~1terraform/$defs/Subscription"
+              }
+            },
+            "servicePrincipals": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1hashicorp~1terraform/$defs/ServicePrincipal"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "ServicePrincipal": {
+          "type": "object",
+          "properties": {
+            "tenantId": {
+              "description": "Tenant ID",
+              "type": "string"
+            },
+            "clientId": {
+              "description": "Application client ID",
+              "type": "string"
+            },
+            "clientSecret": {
+              "description": "Application client secret",
+              "type": "string"
+            },
+            "subscriptionId": {
+              "description": "Azure subscription ID",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Subscription": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "description": "Azure subscription ID",
+              "type": "string"
+            },
+            "backend": {
+              "description": "Backend state storage configuration",
+              "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1hashicorp~1terraform/$defs/Backend"
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
### Description

Adds a new POSH provider for HashiCorp Terraform.

### Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests
- [ ] 🔧 Build/CI

### Related Issue

<!-- Link related issues: Fixes #123, Closes #456 -->

### Changes

- `Command` with subcommands: `init`, `plan`, `apply`, `destroy`, `workspace`, `output`, `state`
- `Config` supporting workspace paths, Azure backend config (resource group, storage account, container), and service principal credentials
- JSON schema for config validation (`config.schema.json`, `config.base.json`)
- Updates `posh.schema.json` with terraform config definitions


### Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
