### PR TITLE
feat: extend go build

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,9 +1,9 @@
 [tools]
 # https://mise-tools.jdx.dev/tools/yq
-yq = "4.53.2"
+yq = "4.53.3"
 # https://mise-tools.jdx.dev/tools/lefthook
 lefthook = "2.1.9"
 # https://mise-tools.jdx.dev/tools/jsonschema
-jsonschema = "15.6.3"
+jsonschema = "16.0.0"
 # https://mise-tools.jdx.dev/tools/golangci-lint
 golangci-lint = "2.12.2"

--- a/golang/command.go
+++ b/golang/command.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"path"
 	"slices"
+	"strings"
+	"time"
 
 	prompt2 "github.com/c-bata/go-prompt"
 	"github.com/foomo/go/options"
@@ -212,17 +214,99 @@ func NewCommand(l log.Logger, cache cache.Cache, opts ...options.Option[*Command
 					fs.Internal().String("tags", "", "Comma separeted string of tags")
 					return nil
 				},
-				Args:    []*tree.Arg{pathModArg},
+				Args: []*tree.Arg{
+					pathModArg,
+					{
+						Name:     "package",
+						Optional: true,
+						Suggest: func(ctx context.Context, p tree.Root, r *readline.Readline) []prompt2.Suggest {
+							return inst.completeTestPackages(ctx, r.Args().At(1))
+						},
+					},
+					{
+						Name:     "test",
+						Optional: true,
+						Suggest: func(ctx context.Context, p tree.Root, r *readline.Readline) []prompt2.Suggest {
+							return inst.completeTests(ctx, r.Args().At(1), r.Args().At(2))
+						},
+					},
+				},
 				Execute: inst.test,
+			},
+			{
+				Name:        "fuzz",
+				Description: "Run go test fuzzing",
+				Flags: func(ctx context.Context, r *readline.Readline, fs *readline.FlagSets) error {
+					fs.Internal().String("tags", "", "Comma separeted string of tags")
+					return nil
+				},
+				Args: []*tree.Arg{
+					pathModArg,
+					{
+						Name:     "package",
+						Optional: true,
+						Suggest: func(ctx context.Context, p tree.Root, r *readline.Readline) []prompt2.Suggest {
+							return inst.completeTestPackages(ctx, r.Args().At(1))
+						},
+					},
+					{
+						Name:     "fuzz",
+						Optional: true,
+						Suggest: func(ctx context.Context, p tree.Root, r *readline.Readline) []prompt2.Suggest {
+							return inst.completeFuzz(ctx, r.Args().At(1), r.Args().At(2))
+						},
+					},
+				},
+				Execute: inst.fuzz,
+			},
+			{
+				Name:        "bench",
+				Description: "Run go test benchmarks",
+				Flags: func(ctx context.Context, r *readline.Readline, fs *readline.FlagSets) error {
+					fs.Internal().String("tags", "", "Comma separeted string of tags")
+					return nil
+				},
+				Args: []*tree.Arg{
+					pathModArg,
+					{
+						Name:     "package",
+						Optional: true,
+						Suggest: func(ctx context.Context, p tree.Root, r *readline.Readline) []prompt2.Suggest {
+							return inst.completeTestPackages(ctx, r.Args().At(1))
+						},
+					},
+					{
+						Name:     "bench",
+						Optional: true,
+						Suggest: func(ctx context.Context, p tree.Root, r *readline.Readline) []prompt2.Suggest {
+							return inst.completeBenchmarks(ctx, r.Args().At(1), r.Args().At(2))
+						},
+					},
+				},
+				Execute: inst.bench,
 			},
 			{
 				Name:        "build",
 				Description: "Run go build",
 				Flags: func(ctx context.Context, r *readline.Readline, fs *readline.FlagSets) error {
 					fs.Internal().Int("parallel", 0, "Number of parallel processes")
+					fs.Internal().Bool("force", false, "Force rebuilding of up-to-date packages (go build -a)")
+					fs.Internal().Bool("verbose", false, "Print the names of packages as they are compiled (go build -v)")
+					fs.Internal().Bool("cgo", false, "Enable cgo (CGO_ENABLED=1)")
+
 					return nil
 				},
-				Args:    []*tree.Arg{pathModArg},
+				Args: []*tree.Arg{
+					pathModArg,
+					{
+						Name:     "package",
+						Repeat:   true,
+						Optional: true,
+						Suggest: func(ctx context.Context, p tree.Root, r *readline.Readline) []prompt2.Suggest {
+							return inst.completePackages(ctx, r.Args().At(1))
+						},
+					},
+				},
 				Execute: inst.build,
 			},
 		},
@@ -293,18 +377,66 @@ func (c *Command) build(ctx context.Context, r *readline.Readline) error {
 		args = r.AdditionalArgs().From(1)
 	}
 
+	if value, _ := r.FlagSets().Internal().GetBool("force"); value {
+		args = append(args, "-a")
+	}
+
+	if value, _ := r.FlagSets().Internal().GetBool("verbose"); value {
+		args = append(args, "-v")
+	}
+
+	var envs []string
+	if value, _ := r.FlagSets().Internal().GetBool("cgo"); value {
+		envs = append(envs, "CGO_ENABLED=1")
+	} else {
+		envs = append(envs, "CGO_ENABLED=0")
+	}
+
+	c.l.Info("Building executables ...")
+
 	ctx, wg := c.wg(ctx, r)
-	c.l.Info("Running go build ...")
 
-	for _, value := range paths {
+	// build only the selected packages
+	if r.Args().HasIndex(2) {
+		start := time.Now()
+
+		for _, value := range r.Args().From(2) {
+			c.l.Infof("🔧 | %s", value)
+		}
+
+		if err := shell.New(ctx, c.l, "go", "build", "-buildvcs=false", "-o", "/dev/null").
+			Args(args...).
+			Args(r.Args().From(2)...).
+			Env(envs...).
+			Dir(r.Args().At(1)).
+			Run(); err != nil {
+			c.l.Errorf("🔧 | build failed ⏱︎ %s", time.Since(start).Truncate(time.Second).String())
+			return err
+		}
+
+		c.l.Successf("🔧 | done ⏱︎ %s", time.Since(start).Truncate(time.Second).String())
+
+		return wg.Wait()
+	}
+
+	for i, value := range paths {
 		wg.Go(func() error {
-			c.l.Info("└ " + value)
+			c.l.Infof("🔧 | [%d|%d] %s", i+1, len(paths), value)
 
-			return shell.New(ctx, c.l, "go", "build", "-v").
+			start := time.Now()
+			if err := shell.New(ctx, c.l, "go", "build", "-buildvcs=false", "-o", "/dev/null").
 				Args(args...).
-				Args("./..."). // TODO select test
+				Args("./...").
+				Env(envs...).
 				Dir(value).
-				Run()
+				Run(); err != nil {
+				c.l.Errorf("🔧 | [%d|%d] %s ⏱︎ %s", i+1, len(paths), value, time.Since(start).Truncate(time.Second).String())
+				return err
+			}
+
+			c.l.Successf("🔧 | [%d|%d] %s ⏱︎ %s", i+1, len(paths), value, time.Since(start).Truncate(time.Second).String())
+
+			return nil
 		})
 	}
 
@@ -312,6 +444,44 @@ func (c *Command) build(ctx context.Context, r *readline.Readline) error {
 }
 
 func (c *Command) test(ctx context.Context, r *readline.Readline) error {
+	return c.goTest(ctx, r, "test", func(name string) []string {
+		if name != "" {
+			return []string{"-run", "^" + name + "$"}
+		}
+
+		return nil
+	}, nil)
+}
+
+func (c *Command) fuzz(ctx context.Context, r *readline.Readline) error {
+	// without a target the corpus is run as regular tests; -fuzz can only target one
+	corpus := []string{"-run", "^Fuzz"}
+
+	return c.goTest(ctx, r, "test fuzz", func(name string) []string {
+		if name != "" {
+			return []string{"-fuzz", "^" + name + "$"}
+		}
+
+		return corpus
+	}, corpus)
+}
+
+func (c *Command) bench(ctx context.Context, r *readline.Readline) error {
+	return c.goTest(ctx, r, "test bench", func(name string) []string {
+		pattern := "."
+		if name != "" {
+			pattern = "^" + name + "$"
+		}
+
+		return []string{"-bench", pattern, "-run", "^$"}
+	}, []string{"-bench", ".", "-run", "^$"})
+}
+
+// goTest runs `go test` for the test/fuzz/bench commands. They share the same MODULE/PACKAGE/TARGET
+// arguments, logging and parallelism; only the extra flags differ: selected(targetName) yields the
+// flags for a chosen package (optionally a single target) and all yields the flags for the
+// per-module `./...` fallback.
+func (c *Command) goTest(ctx context.Context, r *readline.Readline, label string, selected func(name string) []string, all []string) error {
 	var (
 		envs  []string
 		paths []string
@@ -335,19 +505,52 @@ func (c *Command) test(ctx context.Context, r *readline.Readline) error {
 		args = r.AdditionalArgs().From(1)
 	}
 
+	c.l.Infof("Running go %s ...", label)
+
+	// run for the selected package, optionally a single target
+	if pkg := r.Args().At(2); pkg != "" {
+		runArgs := append(slices.Clone(args), selected(r.Args().At(3))...)
+
+		c.l.Infof("🧪 | %s", pkg)
+
+		start := time.Now()
+		if err := shell.New(ctx, c.l, "go", "test", "-v").
+			Args(runArgs...).
+			Args(pkg).
+			Env(envs...).
+			Dir(r.Args().At(1)).
+			Run(); err != nil {
+			c.l.Errorf("🧪 | %s ⏱︎ %s", pkg, time.Since(start).Truncate(time.Second).String())
+			return err
+		}
+
+		c.l.Successf("🧪 | %s ⏱︎ %s", pkg, time.Since(start).Truncate(time.Second).String())
+
+		return nil
+	}
+
+	runArgs := append(slices.Clone(args), all...)
+
 	ctx, wg := c.wg(ctx, r)
-	c.l.Info("Running go test ...")
 
-	for _, value := range paths {
+	for i, value := range paths {
 		wg.Go(func() error {
-			c.l.Info("└ " + value)
+			c.l.Infof("🧪 | [%d|%d] %s", i+1, len(paths), value)
 
-			return shell.New(ctx, c.l, "go", "test", "-v").
-				Args(args...).
-				Args("./..."). // TODO select test
+			start := time.Now()
+			if err := shell.New(ctx, c.l, "go", "test", "-v").
+				Args(runArgs...).
+				Args("./...").
 				Env(envs...).
 				Dir(value).
-				Run()
+				Run(); err != nil {
+				c.l.Errorf("🧪 | [%d|%d] %s ⏱︎ %s", i+1, len(paths), value, time.Since(start).Truncate(time.Second).String())
+				return err
+			}
+
+			c.l.Successf("🧪 | [%d|%d] %s ⏱︎ %s", i+1, len(paths), value, time.Since(start).Truncate(time.Second).String())
+
+			return nil
 		})
 	}
 
@@ -606,6 +809,150 @@ func (c *Command) generate(ctx context.Context, r *readline.Readline) error {
 
 func (c *Command) completePaths(ctx context.Context, filename string, dir bool) []goprompt.Suggest {
 	return suggests.List(c.paths(ctx, filename, dir))
+}
+
+func (c *Command) completePackages(ctx context.Context, dir string) []goprompt.Suggest {
+	return suggests.List(c.packages(ctx, dir))
+}
+
+//nolint:forcetypeassert
+func (c *Command) packages(ctx context.Context, dir string) []string {
+	if dir == "" {
+		dir = "."
+	}
+
+	return c.cache.Get("packages-"+strings.ReplaceAll(dir, "/", "-"), func() any {
+		// only buildable targets, i.e. main packages
+		out, err := shell.New(ctx, c.l, "go", "list", "-find", "-f", `'{{if eq .Name "main"}}{{.ImportPath}}{{end}}'`).
+			Args(c.getBuildTags()...).
+			Args("./...").
+			Quiet().
+			Dir(dir).
+			Output()
+		if err != nil {
+			c.l.Info("failed to list packages", err.Error())
+			return []string{}
+		}
+
+		ret := make([]string, 0)
+
+		for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+			if line != "" {
+				ret = append(ret, line)
+			}
+		}
+
+		slices.Sort(ret)
+
+		return slices.Compact(ret)
+	}).([]string)
+}
+
+func (c *Command) completeTestPackages(ctx context.Context, dir string) []goprompt.Suggest {
+	return suggests.List(c.testPackages(ctx, dir))
+}
+
+//nolint:forcetypeassert
+func (c *Command) testPackages(ctx context.Context, dir string) []string {
+	if dir == "" {
+		dir = "."
+	}
+
+	return c.cache.Get("test-packages-"+strings.ReplaceAll(dir, "/", "-"), func() any {
+		// only packages that contain tests, rendered relative to their module
+		out, err := shell.New(ctx, c.l, "go", "list", "-f", `'{{if or .TestGoFiles .XTestGoFiles}}{{.Module.Path}} {{.ImportPath}}{{end}}'`).
+			Args(c.getBuildTags()...).
+			Args("./...").
+			Quiet().
+			Dir(dir).
+			Output()
+		if err != nil {
+			c.l.Debug("failed to list test packages", err.Error())
+			return []string{}
+		}
+
+		ret := make([]string, 0)
+
+		for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+			module, importPath, ok := strings.Cut(line, " ")
+			if !ok {
+				continue
+			}
+
+			switch {
+			case importPath == module:
+				ret = append(ret, ".")
+			case strings.HasPrefix(importPath, module+"/"):
+				ret = append(ret, "./"+strings.TrimPrefix(importPath, module+"/"))
+			default:
+				ret = append(ret, importPath)
+			}
+		}
+
+		slices.Sort(ret)
+
+		return slices.Compact(ret)
+	}).([]string)
+}
+
+func (c *Command) completeTests(ctx context.Context, dir, pkg string) []goprompt.Suggest {
+	if pkg == "" {
+		return nil
+	}
+
+	return suggests.List(c.list(ctx, dir, pkg, "Test"))
+}
+
+func (c *Command) completeFuzz(ctx context.Context, dir, pkg string) []goprompt.Suggest {
+	if pkg == "" {
+		return nil
+	}
+
+	return suggests.List(c.list(ctx, dir, pkg, "Fuzz"))
+}
+
+func (c *Command) completeBenchmarks(ctx context.Context, dir, pkg string) []goprompt.Suggest {
+	if pkg == "" {
+		return nil
+	}
+
+	return suggests.List(c.list(ctx, dir, pkg, "Benchmark"))
+}
+
+// list returns the names of a single package's tests/fuzz/benchmarks whose name starts with the
+// given prefix (e.g. "Test", "Fuzz", "Benchmark"). Only that package is compiled, so it is fast.
+//
+//nolint:forcetypeassert
+func (c *Command) list(ctx context.Context, dir, pkg, prefix string) []string {
+	if dir == "" {
+		dir = "."
+	}
+
+	return c.cache.Get("list-"+prefix+"-"+strings.ReplaceAll(dir+"-"+pkg, "/", "-"), func() any {
+		out, err := shell.New(ctx, c.l, "go", "test", "-list", "^"+prefix).
+			Args(c.getBuildTags()...).
+			Args(pkg).
+			Quiet().
+			Dir(dir).
+			Output()
+		if err != nil {
+			c.l.Debug("failed to list tests", err.Error())
+			return []string{}
+		}
+
+		ret := make([]string, 0)
+
+		for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+			// -list also prints a trailing "ok <pkg> <time>" summary; keep only matching names
+			if strings.HasPrefix(line, prefix) {
+				ret = append(ret, line)
+			}
+		}
+
+		slices.Sort(ret)
+
+		return slices.Compact(ret)
+	}).([]string)
 }
 
 //nolint:forcetypeassert

--- a/posh.schema.json
+++ b/posh.schema.json
@@ -127,6 +127,22 @@
     {
       "type": "object",
       "properties": {
+        "gh": {
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1cli~1cli"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "properties": {
+        "gnat": {
+          "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1galaxy~1gnat"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "properties": {
         "etcd": {
           "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1etcd-io~1etcd"
         }
@@ -199,7 +215,7 @@
     {
       "type": "object",
       "properties": {
-        "az": {
+        "pulumi": {
           "oneOf": [
             {
               "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1pulumi~1pulumi~1azure"
@@ -1176,6 +1192,51 @@
             },
             "port": {
               "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "https://github.com/foomo/posh-providers/cli/cli": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1cli~1cli/$defs/Config",
+      "$defs": {
+        "Config": {
+          "type": "object",
+          "properties": {
+            "scopes": {
+              "description": "Required OAuth scopes per gh hostname.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "https://github.com/foomo/posh-providers/galaxy/gnat": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1galaxy~1gnat/$defs/Config",
+      "$defs": {
+        "Config": {
+          "type": "object",
+          "properties": {
+            "theme": {
+              "description": "Theme is the gnat color theme, passed to the CLI via -theme.",
+              "type": "string"
+            },
+            "urls": {
+              "description": "URLs maps a name to a NATS server URL; names autocomplete in the shell.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             }
           },
           "additionalProperties": false

--- a/pulumi/pulumi/config.base.json
+++ b/pulumi/pulumi/config.base.json
@@ -3,7 +3,7 @@
 		{
 			"type": "object",
 			"properties": {
-				"az": {
+				"pulumi": {
 					"oneOf": [
 						{
 							"$ref": "https://github.com/foomo/posh-providers/pulumi/pulumi/azure"


### PR DESCRIPTION
### Description

Extends the `golang` posh provider with `fuzz` and `bench` subcommands, richer `test`/`build` argument completion (module → package → target), and new `build` flags. Also bumps `mise`-pinned tooling and fixes the Pulumi config schema key.

### Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests
- [x] 🔧 Build/CI

### Changes

- **`golang`: new `fuzz` and `bench` subcommands** — `test`, `fuzz`, and `bench` now share a common `goTest` runner that differs only in the extra flags (`-run`, `-fuzz`, `-bench`).
- **`golang`: package/target completion** — added `MODULE → PACKAGE → TARGET` argument suggesters (`completePackages`, `completeTestPackages`, `completeTests`, `completeFuzz`, `completeBenchmarks`), each backed by `go list` and cached.
- **`golang`: `build` enhancements** — new `--force` (`-a`), `--verbose` (`-v`), and `--cgo` (`CGO_ENABLED`) flags; selected-package builds; per-package timing and 🔧/🧪 status logging.
- **Deps**: bump `yq` 4.53.2 → 4.53.3 and `jsonschema` 15.6.3 → 16.0.0 in `.mise.toml`; regenerated `posh.schema.json`.
- **`pulumi`: schema fix** — corrected the config key from `az` to `pulumi` in `pulumi/pulumi/config.base.json`.

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
