### PR TITLE
feat(golang): filter go builds

### DIFF
--- a/golang/command.go
+++ b/golang/command.go
@@ -420,13 +420,18 @@ func (c *Command) build(ctx context.Context, r *readline.Readline) error {
 	}
 
 	for i, value := range paths {
+		pkgs := c.packages(ctx, value)
+		if len(pkgs) == 0 {
+			continue
+		}
+
 		wg.Go(func() error {
 			c.l.Infof("🔧 | [%d|%d] %s", i+1, len(paths), value)
 
 			start := time.Now()
 			if err := shell.New(ctx, c.l, "go", "build", "-buildvcs=false", "-o", "/dev/null").
 				Args(args...).
-				Args("./...").
+				Args(pkgs...).
 				Env(envs...).
 				Dir(value).
 				Run(); err != nil {


### PR DESCRIPTION
### Description

Filters `go build` targets to only buildable `main` packages instead of passing `./...`. Paths that contain no `main` package are now skipped entirely, avoiding pointless build invocations.

### Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests
- [ ] 🔧 Build/CI

### Changes

- `golang/command.go`: `build` now calls the existing `c.packages()` helper to resolve buildable `main` packages per path and passes those to `go build` in place of `./...`.
- Skips any path with zero `main` packages (`continue`) so no build is spawned for non-buildable directories.

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.