### PR TITLE
feat: gocontentful region support

### DIFF
--- a/foomo/gocontentful/command.go
+++ b/foomo/gocontentful/command.go
@@ -156,6 +156,7 @@ func (c *Command) execute(ctx context.Context, r *readline.Readline) error {
 
 		if err := shell.New(ctx, c.l, "gocontentful",
 			"-spaceid", cfg.SpaceID, "-cmakey", cfg.CMAKey, "-environment", cfg.Environment,
+			"-region", cfg.Region,
 			"-contenttypes", strings.Join(cfg.ContentTypes, ","), dir).
 			Args(r.AdditionalArgs()...).
 			Run(); err != nil {

--- a/foomo/gocontentful/config.go
+++ b/foomo/gocontentful/config.go
@@ -4,5 +4,6 @@ type Config struct {
 	SpaceID      string   `json:"spaceId" yaml:"spaceId"`
 	CMAKey       string   `json:"cmaKey" yaml:"cmaKey"`
 	Environment  string   `json:"environment,omitempty" yaml:"environment,omitempty"`
+	Region       string   `json:"region,omitempty" yaml:"region,omitempty"`
 	ContentTypes []string `json:"contentTypes" yaml:"contentTypes"`
 }

--- a/foomo/gocontentful/config.schema.json
+++ b/foomo/gocontentful/config.schema.json
@@ -14,6 +14,9 @@
         "environment": {
           "type": "string"
         },
+        "region": {
+          "type": "string"
+        },
         "contentTypes": {
           "items": {
             "type": "string"


### PR DESCRIPTION
### Description

Adds `-region` passthrough to the `gocontentful` posh command. The generator (`foomo/gocontentful` v1.2.5+) supports a `region` config key to target Contentful's EU infrastructure, but this wrapper's own `Config` struct didn't know about it, so the value was silently dropped and never reached the CLI.

### Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests
- [ ] 🔧 Build/CI

### Changes

- `gocontentful/config.go`: add `Region string` field (`yaml:"region,omitempty"`)
- `gocontentful/command.go`: forward `cfg.Region` as `-region` to the underlying `gocontentful` CLI call

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.