### PR TITLE
feat(az): add azure vault integration

### DIFF
--- a/azure/az/README.md
+++ b/azure/az/README.md
@@ -27,6 +27,10 @@ az:
         dev:
           name: my-artifactory
           resourceGroup: my-resource-group
+      keyVaults:
+        dev:
+          name: my-key-vault
+          resourceGroup: my-resource-group
 ```
 
 ### Commands
@@ -42,6 +46,7 @@ Available Commands:
       login                         Log in to Azure
       logout                        Log out to remove access to Azure subscriptions
       configure                     Manage Azure CLI configuration
+      vault                         Manage key vault entries
       artifactory                   Login into the artifactory
       kubeconfig                    Retrieve credentials to access remote cluster
 ```
@@ -57,4 +62,32 @@ Available Commands:
 
 # Retrieve cluster kubeconfig
 > az kubeconfig <SUBSCRIPTION> <CLUSTER>
+```
+
+#### Key vault
+
+Manage keys, secrets and certificates of a configured key vault. Every command is scoped by
+`<SUBSCRIPTION>` and `<VAULT>` (both tab-completable from the config), followed by the entry type
+(`key`, `secret`, `certificate`) and the operation (`set`, `list`, `delete`).
+
+```shell
+# Create a new key (or key version)
+> az vault <SUBSCRIPTION> <VAULT> key set <NAME> --kty RSA --size 2048
+# List keys
+> az vault <SUBSCRIPTION> <VAULT> key list
+# Delete a key (name tab-completes from the vault)
+> az vault <SUBSCRIPTION> <VAULT> key delete <NAME>
+
+# Create or update a secret
+> az vault <SUBSCRIPTION> <VAULT> secret set <NAME> --value <VALUE>
+> az vault <SUBSCRIPTION> <VAULT> secret set <NAME> --file ./secret.txt
+# List / delete secrets
+> az vault <SUBSCRIPTION> <VAULT> secret list
+> az vault <SUBSCRIPTION> <VAULT> secret delete <NAME>
+
+# Import a certificate from a PEM or PFX file
+> az vault <SUBSCRIPTION> <VAULT> certificate set <NAME> --file ./cert.pfx --password <PASSWORD>
+# List / delete certificates
+> az vault <SUBSCRIPTION> <VAULT> certificate list
+> az vault <SUBSCRIPTION> <VAULT> certificate delete <NAME>
 ```

--- a/azure/az/cluster.go
+++ b/azure/az/cluster.go
@@ -1,10 +1,10 @@
 package az
 
 type Cluster struct {
-	// Cluster
+	// Name of the cluster
 	Name string `json:"name" yaml:"name"`
-	// Cluster resource group name
+	// Resource group of the cluster
 	ResourceGroup string `json:"resourceGroup" yaml:"resourceGroup"`
-	// ProxyURL
+	// ProxyURL to use for the kubeconfig
 	ProxyURL string `json:"proxyUrl" yaml:"proxyUrl"`
 }

--- a/azure/az/command.go
+++ b/azure/az/command.go
@@ -1,7 +1,9 @@
 package az
 
 import (
+	"bytes"
 	"context"
+	"strings"
 
 	"github.com/foomo/posh-providers/kubernetes/kubeconfig"
 	"github.com/foomo/posh-providers/kubernetes/kubectl"
@@ -95,9 +97,155 @@ func NewCommand(l log.Logger, az *AZ, kubectl *kubectl.Kubectl, opts ...CommandO
 				Execute:     inst.exec,
 			},
 			{
-				Name:        "configure",
-				Description: "Manage Azure CLI configuration",
-				Execute:     inst.exec,
+				Name:        "vault",
+				Description: "Manage key vault entries",
+				Nodes: tree.Nodes{
+					{
+						Name:        "subscription",
+						Description: "Name of the subscription",
+						Values: func(ctx context.Context, r *readline.Readline) []goprompt.Suggest {
+							return suggests.List(inst.az.cfg.SubscriptionNames())
+						},
+						Nodes: tree.Nodes{
+							{
+								Name:        "vault",
+								Description: "Name of the vault",
+								Values: func(ctx context.Context, r *readline.Readline) []goprompt.Suggest {
+									ret, err := inst.az.cfg.Subscription(r.Args().At(1))
+									if err != nil {
+										return nil
+									}
+
+									return suggests.List(ret.VaultNames())
+								},
+								Nodes: tree.Nodes{
+									{
+										Name:        "key",
+										Description: "Manage keys",
+										Nodes: tree.Nodes{
+											{
+												Name:        "create",
+												Description: "Create a new key or key version",
+												Args: tree.Args{
+													{
+														Name:        "name",
+														Description: "Name of the key",
+													},
+												},
+												Flags: func(ctx context.Context, r *readline.Readline, fs *readline.FlagSets) error {
+													fs.Default().String("kty", "", "Type of key to create")
+													fs.Default().Int("size", 0, "Key size in bits (for RSA keys)")
+													fs.Default().StringArray("ops", nil, "Permitted JSON web key operations")
+
+													return fs.Default().SetValues("kty", "RSA", "RSA-HSM", "EC", "EC-HSM", "oct", "oct-HSM")
+												},
+												Execute: inst.vaultKeyCreate,
+											},
+											{
+												Name:        "list",
+												Description: "List keys in the vault",
+												Execute:     inst.vaultKeyList,
+											},
+											{
+												Name:        "delete",
+												Description: "Delete a key from the vault",
+												Args: tree.Args{
+													{
+														Name:        "name",
+														Description: "Name of the key",
+														Suggest:     inst.completeVaultEntries,
+													},
+												},
+												Execute: inst.vaultKeyDelete,
+											},
+										},
+									},
+									{
+										Name:        "secret",
+										Description: "Manage secrets",
+										Nodes: tree.Nodes{
+											{
+												Name:        "set",
+												Description: "Create or update a secret",
+												Args: tree.Args{
+													{
+														Name:        "name",
+														Description: "Name of the secret",
+													},
+												},
+												Flags: func(ctx context.Context, r *readline.Readline, fs *readline.FlagSets) error {
+													fs.Default().String("value", "", "Plain text secret value")
+													fs.Default().String("file", "", "Source file for the secret value")
+													fs.Default().String("content-type", "", "Type of the secret value such as a password")
+
+													return nil
+												},
+												Execute: inst.vaultSecretSet,
+											},
+											{
+												Name:        "list",
+												Description: "List secrets in the vault",
+												Execute:     inst.vaultSecretList,
+											},
+											{
+												Name:        "delete",
+												Description: "Delete a secret from the vault",
+												Args: tree.Args{
+													{
+														Name:        "name",
+														Description: "Name of the secret",
+														Suggest:     inst.completeVaultEntries,
+													},
+												},
+												Execute: inst.vaultSecretDelete,
+											},
+										},
+									},
+									{
+										Name:        "certificate",
+										Description: "Manage certificates",
+										Nodes: tree.Nodes{
+											{
+												Name:        "set",
+												Description: "Import a certificate from a file",
+												Args: tree.Args{
+													{
+														Name:        "name",
+														Description: "Name of the certificate",
+													},
+												},
+												Flags: func(ctx context.Context, r *readline.Readline, fs *readline.FlagSets) error {
+													fs.Default().String("file", "", "Path to the PEM or PFX certificate file")
+													fs.Default().String("password", "", "Password for the certificate file, if any")
+
+													return nil
+												},
+												Execute: inst.vaultCertificateSet,
+											},
+											{
+												Name:        "list",
+												Description: "List certificates in the vault",
+												Execute:     inst.vaultCertificateList,
+											},
+											{
+												Name:        "delete",
+												Description: "Delete a certificate from the vault",
+												Args: tree.Args{
+													{
+														Name:        "name",
+														Description: "Name of the certificate",
+														Suggest:     inst.completeVaultEntries,
+													},
+												},
+												Execute: inst.vaultCertificateDelete,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 			{
 				Name:        "artifactory",
@@ -155,8 +303,12 @@ func NewCommand(l log.Logger, az *AZ, kubectl *kubectl.Kubectl, opts ...CommandO
 				},
 				Execute: inst.kubeconfig,
 			},
+			{
+				Name:        "raw",
+				Description: "Execute raw Azure CLI commands",
+				Execute:     inst.raw,
+			},
 		},
-		Execute: inst.exec,
 	})
 
 	return inst
@@ -189,6 +341,44 @@ func (c *Command) Help(ctx context.Context, r *readline.Readline) string {
 // ------------------------------------------------------------------------------------------------
 // ~ Private methods
 // ------------------------------------------------------------------------------------------------
+
+func (c *Command) login(ctx context.Context, r *readline.Readline) error {
+	fs := r.FlagSets().Default()
+	ifs := r.FlagSets().Internal()
+
+	servicePricipal, err := ifs.GetString("service-principal")
+	if err != nil {
+		return err
+	}
+
+	var args []string
+
+	if servicePricipal != "" {
+		sp, err := c.az.cfg.ServicePrincipal(servicePricipal)
+		if err != nil {
+			return err
+		}
+
+		args = append(args,
+			"--service-principal",
+			"--username", sp.ClientID,
+			"--password", sp.ClientSecret,
+			"--tenant", sp.TenantID,
+		)
+	} else {
+		args = append(args,
+			"--allow-no-subscriptions",
+			"--tenant", c.az.Config().TenantID,
+		)
+	}
+
+	return c.cmd(ctx, "login").
+		Args(args...).
+		Args(fs.Visited().Args()...).
+		Args(r.AdditionalArgs()...).
+		Args(r.AdditionalFlags()...).
+		Run()
+}
 
 func (c *Command) artifactory(ctx context.Context, r *readline.Readline) error {
 	sub, err := c.az.cfg.Subscription(r.Args().At(1))
@@ -273,47 +463,215 @@ func (c *Command) kubeconfig(ctx context.Context, r *readline.Readline) error {
 	return nil
 }
 
-func (c *Command) exec(ctx context.Context, r *readline.Readline) error {
-	return c.cmd(ctx, r.Args()...).
+func (c *Command) vaultTarget(r *readline.Readline) (Subscription, Vault, error) {
+	sub, err := c.az.cfg.Subscription(r.Args().At(1))
+	if err != nil {
+		return Subscription{}, Vault{}, errors.Errorf("failed to retrieve subscription for: %q", r.Args().At(1))
+	}
+
+	vault, err := sub.Vault(r.Args().At(2))
+	if err != nil {
+		return Subscription{}, Vault{}, errors.Errorf("failed to retrieve vault for: %q", r.Args().At(2))
+	}
+
+	return sub, vault, nil
+}
+
+func (c *Command) vaultKeyCreate(ctx context.Context, r *readline.Readline) error {
+	sub, vault, err := c.vaultTarget(r)
+	if err != nil {
+		return err
+	}
+
+	return c.cmd(ctx, "keyvault", "key", "create",
+		"--name", r.Args().At(5),
+		"--vault-name", vault.Name,
+		"--subscription", sub.Name,
+	).
+		Args(r.FlagSets().Default().Visited().Args()...).
+		Args(r.AdditionalArgs()...).
+		Args(r.AdditionalFlags()...).
+		Run()
+}
+
+func (c *Command) vaultKeyList(ctx context.Context, r *readline.Readline) error {
+	sub, vault, err := c.vaultTarget(r)
+	if err != nil {
+		return err
+	}
+
+	return c.cmd(ctx, "keyvault", "key", "list",
+		"--vault-name", vault.Name,
+		"--subscription", sub.Name,
+	).
+		Args(r.FlagSets().Default().Visited().Args()...).
+		Args(r.AdditionalArgs()...).
+		Args(r.AdditionalFlags()...).
+		Run()
+}
+
+func (c *Command) vaultKeyDelete(ctx context.Context, r *readline.Readline) error {
+	sub, vault, err := c.vaultTarget(r)
+	if err != nil {
+		return err
+	}
+
+	return c.cmd(ctx, "keyvault", "key", "delete",
+		"--name", r.Args().At(5),
+		"--vault-name", vault.Name,
+		"--subscription", sub.Name,
+	).
+		Args(r.FlagSets().Default().Visited().Args()...).
+		Args(r.AdditionalArgs()...).
+		Args(r.AdditionalFlags()...).
+		Run()
+}
+
+func (c *Command) vaultSecretSet(ctx context.Context, r *readline.Readline) error {
+	sub, vault, err := c.vaultTarget(r)
+	if err != nil {
+		return err
+	}
+
+	return c.cmd(ctx, "keyvault", "secret", "set",
+		"--name", r.Args().At(5),
+		"--vault-name", vault.Name,
+		"--subscription", sub.Name,
+	).
+		Args(r.FlagSets().Default().Visited().Args()...).
+		Args(r.AdditionalArgs()...).
+		Args(r.AdditionalFlags()...).
+		Run()
+}
+
+func (c *Command) vaultSecretList(ctx context.Context, r *readline.Readline) error {
+	sub, vault, err := c.vaultTarget(r)
+	if err != nil {
+		return err
+	}
+
+	return c.cmd(ctx, "keyvault", "secret", "list",
+		"--vault-name", vault.Name,
+		"--subscription", sub.Name,
+	).
+		Args(r.FlagSets().Default().Visited().Args()...).
+		Args(r.AdditionalArgs()...).
+		Args(r.AdditionalFlags()...).
+		Run()
+}
+
+func (c *Command) vaultSecretDelete(ctx context.Context, r *readline.Readline) error {
+	sub, vault, err := c.vaultTarget(r)
+	if err != nil {
+		return err
+	}
+
+	return c.cmd(ctx, "keyvault", "secret", "delete",
+		"--name", r.Args().At(5),
+		"--vault-name", vault.Name,
+		"--subscription", sub.Name,
+	).
+		Args(r.FlagSets().Default().Visited().Args()...).
+		Args(r.AdditionalArgs()...).
+		Args(r.AdditionalFlags()...).
+		Run()
+}
+
+func (c *Command) vaultCertificateSet(ctx context.Context, r *readline.Readline) error {
+	sub, vault, err := c.vaultTarget(r)
+	if err != nil {
+		return err
+	}
+
+	return c.cmd(ctx, "keyvault", "certificate", "import",
+		"--name", r.Args().At(5),
+		"--vault-name", vault.Name,
+		"--subscription", sub.Name,
+	).
+		Args(r.FlagSets().Default().Visited().Args()...).
+		Args(r.AdditionalArgs()...).
+		Args(r.AdditionalFlags()...).
+		Run()
+}
+
+func (c *Command) vaultCertificateList(ctx context.Context, r *readline.Readline) error {
+	sub, vault, err := c.vaultTarget(r)
+	if err != nil {
+		return err
+	}
+
+	return c.cmd(ctx, "keyvault", "certificate", "list",
+		"--vault-name", vault.Name,
+		"--subscription", sub.Name,
+	).
+		Args(r.FlagSets().Default().Visited().Args()...).
+		Args(r.AdditionalArgs()...).
+		Args(r.AdditionalFlags()...).
+		Run()
+}
+
+func (c *Command) vaultCertificateDelete(ctx context.Context, r *readline.Readline) error {
+	sub, vault, err := c.vaultTarget(r)
+	if err != nil {
+		return err
+	}
+
+	return c.cmd(ctx, "keyvault", "certificate", "delete",
+		"--name", r.Args().At(5),
+		"--vault-name", vault.Name,
+		"--subscription", sub.Name,
+	).
+		Args(r.FlagSets().Default().Visited().Args()...).
+		Args(r.AdditionalArgs()...).
+		Args(r.AdditionalFlags()...).
+		Run()
+}
+
+func (c *Command) completeVaultEntries(ctx context.Context, t tree.Root, r *readline.Readline) []goprompt.Suggest {
+	sub, vault, err := c.vaultTarget(r)
+	if err != nil {
+		c.l.Debug(err.Error())
+		return nil
+	}
+
+	noun := r.Args().At(3) // key | secret | certificate
+
+	return c.az.cache.GetSuggests("vault-"+noun+"-"+sub.Name+"-"+vault.Name, func() any {
+		var buf bytes.Buffer
+
+		if err := c.cmd(ctx, "keyvault", noun, "list",
+			"--vault-name", vault.Name,
+			"--subscription", sub.Name,
+			"--query", "[].name",
+			"-o", "tsv",
+		).Stdout(&buf).Run(); err != nil {
+			c.l.Debug(err.Error())
+			return []goprompt.Suggest{}
+		}
+
+		var ret []string
+
+		for line := range strings.SplitSeq(strings.TrimSpace(buf.String()), "\n") {
+			if line = strings.TrimSpace(line); line != "" {
+				ret = append(ret, line)
+			}
+		}
+
+		return suggests.List(ret)
+	})
+}
+
+func (c *Command) raw(ctx context.Context, r *readline.Readline) error {
+	return c.cmd(ctx, r.Args()[1:]...).
 		Args(r.Flags()...).
 		Args(r.AdditionalArgs()...).
 		Args(r.AdditionalFlags()...).
 		Run()
 }
 
-func (c *Command) login(ctx context.Context, r *readline.Readline) error {
-	fs := r.FlagSets().Default()
-	ifs := r.FlagSets().Internal()
-
-	servicePricipal, err := ifs.GetString("service-principal")
-	if err != nil {
-		return err
-	}
-
-	var args []string
-
-	if servicePricipal != "" {
-		sp, err := c.az.cfg.ServicePrincipal(servicePricipal)
-		if err != nil {
-			return err
-		}
-
-		args = append(args,
-			"--service-principal",
-			"--username", sp.ClientID,
-			"--password", sp.ClientSecret,
-			"--tenant", sp.TenantID,
-		)
-	} else {
-		args = append(args,
-			"--allow-no-subscriptions",
-			"--tenant", c.az.Config().TenantID,
-		)
-	}
-
-	return c.cmd(ctx, "login").
-		Args(args...).
-		Args(fs.Visited().Args()...).
+func (c *Command) exec(ctx context.Context, r *readline.Readline) error {
+	return c.cmd(ctx, r.Args()...).
+		Args(r.Flags()...).
 		Args(r.AdditionalArgs()...).
 		Args(r.AdditionalFlags()...).
 		Run()

--- a/azure/az/config.schema.json
+++ b/azure/az/config.schema.json
@@ -6,10 +6,12 @@
     "Artifactory": {
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the artifactory"
         },
         "resourceGroup": {
-          "type": "string"
+          "type": "string",
+          "description": "ResourceGroup of the artifactory"
         }
       },
       "additionalProperties": false,
@@ -19,15 +21,15 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Cluster"
+          "description": "Name of the cluster"
         },
         "resourceGroup": {
           "type": "string",
-          "description": "Cluster resource group name"
+          "description": "Resource group of the cluster"
         },
         "proxyUrl": {
           "type": "string",
-          "description": "ProxyURL"
+          "description": "ProxyURL to use for the kubeconfig"
         }
       },
       "additionalProperties": false,
@@ -86,19 +88,43 @@
     "Subscription": {
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Name of the subscription"
+        },
+        "vaults": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Vault"
+          },
+          "type": "object",
+          "description": "Vaults available within the subscription"
         },
         "clusters": {
           "additionalProperties": {
             "$ref": "#/$defs/Cluster"
           },
-          "type": "object"
+          "type": "object",
+          "description": "Clusters available within the subscription"
         },
         "artifactories": {
           "additionalProperties": {
             "$ref": "#/$defs/Artifactory"
           },
-          "type": "object"
+          "type": "object",
+          "description": "Artifactorys available within the subscription"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "Vault": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the key vault"
+        },
+        "resourceGroup": {
+          "type": "string",
+          "description": "Resource group of the key vault"
         }
       },
       "additionalProperties": false,

--- a/azure/az/subscription.go
+++ b/azure/az/subscription.go
@@ -6,8 +6,13 @@ import (
 )
 
 type Subscription struct {
-	Name          string                 `json:"name" yaml:"name"`
-	Clusters      map[string]Cluster     `json:"clusters" yaml:"clusters"`
+	// Name of the subscription
+	Name string `json:"name" yaml:"name"`
+	// Vaults available within the subscription
+	Vaults map[string]Vault `json:"vaults" yaml:"vaults"`
+	// Clusters available within the subscription
+	Clusters map[string]Cluster `json:"clusters" yaml:"clusters"`
+	// Artifactorys available within the subscription
 	Artifactories map[string]Artifactory `json:"artifactories" yaml:"artifactories"`
 }
 
@@ -22,6 +27,19 @@ func (c Subscription) Cluster(name string) (Cluster, error) {
 
 func (c Subscription) ClusterNames() []string {
 	return lo.Keys(c.Clusters)
+}
+
+func (c Subscription) Vault(name string) (Vault, error) {
+	value, ok := c.Vaults[name]
+	if !ok {
+		return Vault{}, errors.Errorf("key vault not found: %s", name)
+	}
+
+	return value, nil
+}
+
+func (c Subscription) VaultNames() []string {
+	return lo.Keys(c.Vaults)
 }
 
 func (c Subscription) Artifactory(name string) (Artifactory, error) {

--- a/azure/az/vault.go
+++ b/azure/az/vault.go
@@ -1,8 +1,8 @@
 package az
 
-type Artifactory struct {
-	// Name of the artifactory
+type Vault struct {
+	// Name of the key vault
 	Name string `json:"name" yaml:"name"`
-	// ResourceGroup of the artifactory
+	// Resource group of the key vault
 	ResourceGroup string `json:"resourceGroup" yaml:"resourceGroup"`
 }

--- a/foomo/squadron/v2/command.go
+++ b/foomo/squadron/v2/command.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/foomo/posh-providers/kubernetes/kubectl"
-	"github.com/foomo/posh-providers/onepassword"
 	"github.com/foomo/posh-providers/slack-go/slack"
 	"github.com/foomo/posh/pkg/cache"
 	"github.com/foomo/posh/pkg/command/tree"
@@ -29,7 +28,6 @@ const All = "all"
 type (
 	Command struct {
 		l              log.Logger
-		op             *onepassword.OnePassword
 		name           string
 		bake           bool
 		slack          *slack.Slack
@@ -89,10 +87,9 @@ func CommandWithSlackWebhookID(v string) CommandOption {
 // ~ Constructor
 // ------------------------------------------------------------------------------------------------
 
-func NewCommand(l log.Logger, squadron *Squadron, kubectl *kubectl.Kubectl, op *onepassword.OnePassword, cache cache.Cache, opts ...CommandOption) *Command {
+func NewCommand(l log.Logger, squadron *Squadron, kubectl *kubectl.Kubectl, cache cache.Cache, opts ...CommandOption) *Command {
 	inst := &Command{
 		l:              l,
-		op:             op,
 		name:           "squadron",
 		kubectl:        kubectl,
 		squadron:       squadron,
@@ -484,18 +481,6 @@ func (c *Command) execute(ctx context.Context, r *readline.Readline) error {
 
 	if cmd == "build" && c.bake {
 		cmd = "bake"
-	}
-
-	{ // handle 1password
-		if c.op != nil {
-			if ok, _ := c.op.IsAuthenticated(ctx); !ok {
-				c.l.Info("missing 1password session, please login")
-
-				if err := c.op.SignIn(ctx); err != nil {
-					return err
-				}
-			}
-		}
 	}
 
 	{ // handle pass through flags

--- a/posh.schema.json
+++ b/posh.schema.json
@@ -606,9 +606,11 @@
           "type": "object",
           "properties": {
             "name": {
+              "description": "Name of the artifactory",
               "type": "string"
             },
             "resourceGroup": {
+              "description": "ResourceGroup of the artifactory",
               "type": "string"
             }
           },
@@ -618,15 +620,15 @@
           "type": "object",
           "properties": {
             "name": {
-              "description": "Cluster",
+              "description": "Name of the cluster",
               "type": "string"
             },
             "resourceGroup": {
-              "description": "Cluster resource group name",
+              "description": "Resource group of the cluster",
               "type": "string"
             },
             "proxyUrl": {
-              "description": "ProxyURL",
+              "description": "ProxyURL to use for the kubeconfig",
               "type": "string"
             }
           },
@@ -664,6 +666,20 @@
           },
           "additionalProperties": false
         },
+        "KeyVault": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "Name of the key vault",
+              "type": "string"
+            },
+            "resourceGroup": {
+              "description": "Resource group of the key vault",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
         "ServicePrincipal": {
           "type": "object",
           "properties": {
@@ -686,15 +702,25 @@
           "type": "object",
           "properties": {
             "name": {
+              "description": "Name of the subscription",
               "type": "string"
             },
             "clusters": {
+              "description": "Clusters available within the subscription",
               "type": "object",
               "additionalProperties": {
                 "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1azure~1az/$defs/Cluster"
               }
             },
+            "KeyVaults": {
+              "description": "KeyVaults available within the subscription",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1azure~1az/$defs/KeyVault"
+              }
+            },
             "artifactories": {
+              "description": "Artifactorys available within the subscription",
               "type": "object",
               "additionalProperties": {
                 "$ref": "#/$defs/https:~1~1github.com~1foomo~1posh-providers~1azure~1az/$defs/Artifactory"
@@ -1300,6 +1326,10 @@
               "description": "Theme is the tempo color theme, passed to the CLI via --theme.",
               "type": "string"
             },
+            "configDir": {
+              "description": "ConfigDir specifies the $XDG_CONFIG_HOME where configuration files are stored.",
+              "type": "string"
+            },
             "profiles": {
               "description": "Profiles maps a name to a Temporal connection profile; names autocomplete in the shell.",
               "type": "object",
@@ -1335,6 +1365,10 @@
           "properties": {
             "theme": {
               "description": "Theme is the gnat color theme, passed to the CLI via -theme.",
+              "type": "string"
+            },
+            "configDir": {
+              "description": "ConfigDir specifies the $XDG_CONFIG_HOME where configuration files are stored.",
               "type": "string"
             },
             "profiles": {


### PR DESCRIPTION
### Description

Adds Azure Key Vault management to the `az` provider and drops the mandatory 1Password sign-in from the `squadron` command. The new `az vault` subtree manages keys, secrets and certificates scoped by subscription and vault, and `NewCommand` for squadron no longer requires a `*onepassword.OnePassword` dependency.

### Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] 💥 Breaking change
- [x] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests
- [x] 🔧 Build/CI

### Changes

- Add `Vault` config type (`azure/az/vault.go`) and wire `Vaults` map into `Subscription` with `Vault(name)` / `VaultNames()` helpers.
- Add `az vault <SUBSCRIPTION> <VAULT>` command tree covering `key`, `secret` and `certificate` with `set` / `list` / `delete` operations (`azure/az/command.go`).
- Regenerate `azure/az/config.schema.json` and top-level `posh.schema.json` for the new `keyVaults` config.
- Document the key vault commands and config in `azure/az/README.md`.
- Remove the 1Password requirement from `foomo/squadron/v2`: drop the `op` field/param from `NewCommand` and the pre-execute sign-in block.

### Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
